### PR TITLE
Adds transpiling, minification, logic improvement

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,3 @@
+{
+  "presets": ["@babel/env"]
+}

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -13,6 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - run: yarn install
+      - run: yarn build
       - name: Publish
         uses: cloudflare/wrangler-action@2.0.0
         with:

--- a/.github/workflows/deploy-stage.yml
+++ b/.github/workflows/deploy-stage.yml
@@ -13,6 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - run: yarn install
+      - run: yarn build
       - name: Publish
         uses: cloudflare/wrangler-action@2.0.0
         with:

--- a/assets/static/js/main.js
+++ b/assets/static/js/main.js
@@ -230,6 +230,15 @@
       itemIndex++
     }
 
+    if (itemIndex > 0) {
+      const timeDiffFromPrev = currentUTC - list[itemIndex - 1].dt
+      const timeDiffFromCurrent = list[itemIndex].dt - currentUTC
+
+      if (timeDiffFromPrev < timeDiffFromCurrent) {
+        itemIndex = itemIndex - 1
+      }
+    }
+
     return itemIndex
   }
 
@@ -252,7 +261,9 @@
 
     const weatherListContainer = document.querySelector('#weather-item-list')
     const frag = document.createDocumentFragment()
-    list.slice(currentIndex, currentIndex + 5).forEach((item) => {
+    const windowSize = 5
+    const currentWindow = list.slice(currentIndex, currentIndex <= windowSize - 1 ? currentIndex + windowSize : list.length - 1)
+    currentWindow.forEach((item, index) => {
       const { dt, main: { temp }, weather } = item
 
       const { icon } = getWeatherImagesById(weather[0]?.id, dt)
@@ -263,7 +274,7 @@
       node.classList.remove('dummy-node')
       node.querySelector('.item-temp').innerText = getTemp(temp)
       node.querySelector('.item-icon').setAttribute('src', `${iconsPath}/${icon}.svg`)
-      node.querySelector('.item-time').innerText = formatTime(dateTime)
+      node.querySelector('.item-time').innerText = index === 0 ? 'Current' : formatTime(dateTime)
 
       frag.appendChild(node)
     })
@@ -271,7 +282,7 @@
     weatherListContainer.innerHTML = ''
     weatherListContainer.appendChild(frag)
     // Refresh weather from local list every 15 mins
-    weatherTimer = setTimeout(() => updateWeather(list), 15 * 60 * 1000)
+    weatherTimer = setTimeout(() => updateWeather(list), 10 * 60 * 1000)
   }
 
   const updateData = (data) => {

--- a/assets/static/styles/main.css
+++ b/assets/static/styles/main.css
@@ -51,7 +51,6 @@ body {
 
 .location-item {
   display: flex;
-  column-gap: 10px;
   justify-content: center;
   align-items: center;
   max-width: fit-content;
@@ -62,6 +61,7 @@ body {
 }
 
 .location-item img {
+  margin-right: 10px;
   width: 0.9rem;
 }
 
@@ -92,10 +92,10 @@ body {
 .weather-condition {
   display: flex;
   align-items: center;
-  column-gap: 8px;
 }
 
 #current-weather-status {
+  margin-left: 8px;
   text-transform: capitalize;
 }
 
@@ -114,10 +114,14 @@ body {
   flex-direction: column;
   justify-content: center;
   align-items: center;
-  row-gap: 0.5rem;
+}
+
+.weather-item .item-icon {
+  margin-top: 0.5rem;
 }
 
 .weather-item .item-time {
+  margin-top: 0.5rem;
   white-space: nowrap;
 }
 
@@ -147,8 +151,8 @@ body {
     font-size: 2.5rem;
   }
 
-  #weather-item-list {
-    column-gap: 2.5rem;
+  .weather-item + .weather-item {
+    margin-left: 2.5rem;
   }
 
   .weather-item .item-temp-degree {
@@ -200,8 +204,8 @@ body {
     font-size: 2.75rem;
   }
 
-  #weather-item-list {
-    column-gap: 3rem;
+  .weather-item + .weather-item {
+    margin-left: 3rem;
   }
 
   .weather-item .item-temp-degree {
@@ -251,8 +255,8 @@ body {
     font-size: 2.75rem;
   }
 
-  #weather-item-list {
-    column-gap: 2.3rem;
+  .weather-item + .weather-item {
+    margin-left: 2.3rem;
   }
 
   .weather-item .item-temp-degree {
@@ -302,8 +306,8 @@ body {
     font-size: 2.75rem;
   }
 
-  #weather-item-list {
-    column-gap: 2.6rem;
+  .weather-item + .weather-item {
+    margin-left: 2.6rem;
   }
 
   .weather-item .item-temp-degree {
@@ -353,8 +357,8 @@ body {
     font-size: 2.75rem;
   }
 
-  #weather-item-list {
-    column-gap: 3.3rem;
+  .weather-item + .weather-item {
+    margin-left: 3.3rem;
   }
 
   .weather-item .item-temp-degree {
@@ -386,24 +390,20 @@ body {
 
   .location {
     flex-direction: column;
-    row-gap: 0.3rem;
     font-size: 0.9rem;
-    column-gap: 0.3rem;
     justify-content: center;
     margin-top: 1.2rem;
     width: 100%;
   }
 
-  .location-item {
-    column-gap: 5px;
-  }
-
   .location-item + .location-item {
+    margin-top: 0.3rem;
     margin-left: 0;
   }
 
   .location-item img {
     width: 0.9rem;
+    margin-right: 5px;
   }
 
   .upgrade-banner {
@@ -430,8 +430,11 @@ body {
   #weather-item-list {
     justify-content: space-between;
     align-self: unset;
-    column-gap: 1rem;
     margin-top: 25px;
+  }
+
+  .weather-item + .weather-item {
+    margin-left: 1rem;
   }
 
   .weather-item .item-temp-degree {
@@ -463,19 +466,15 @@ body {
   .location {
     flex-direction: row;
     font-size: 0.875rem;
-    column-gap: 0.5rem;
     margin-top: 1.6rem;
   }
 
-  .location-item {
-    column-gap: 10px;
-  }
-
   .location-item + .location-item {
-    margin-left: 2rem;
+    margin-left: 2.5rem;
   }
 
   .location-item img {
+    margin-right: 10px;
     width: 1.2rem;
   }
 
@@ -497,8 +496,11 @@ body {
   }
 
   #weather-item-list {
-    column-gap: 2.8rem;
     margin-top: 30px;
+  }
+
+  .weather-item + .weather-item {
+    margin-left: 2.8rem;
   }
 
   .weather-item .item-temp-degree {
@@ -545,8 +547,11 @@ body {
   }
 
   #weather-item-list {
-    column-gap: 1.5rem;
     margin-top: 30px;
+  }
+
+  .weather-item + .weather-item {
+    margin-left: 1.5rem;
   }
 
   .weather-item .item-temp-degree {
@@ -558,7 +563,7 @@ body {
   }
 
   .weather-item .item-time {
-    font-size: 1.25rem;
+    font-size: 1rem;
   }
 }
 
@@ -597,8 +602,11 @@ body {
   }
 
   #weather-item-list {
-    column-gap: 1.5rem;
     margin-top: 75px;
+  }
+
+  .weather-item + .weather-item {
+    margin-left: 1.5rem;
   }
 
   .weather-item .item-temp-degree {
@@ -645,9 +653,8 @@ body {
     font-size: 2.75rem;
   }
 
-  #weather-item-list {
-    column-gap: 2.8rem;
-    margin-top: 128px;
+  .weather-item + .weather-item {
+    margin-left: 2.8rem;
   }
 
   .weather-item .item-temp-degree {
@@ -677,17 +684,20 @@ body {
     margin-top: 1.42rem;
   }
 
-  .location-item {
-    column-gap: 20px;
+  .location-item img {
+    margin-right: 20px;
   }
 
   .weather-condition {
     font-size: 1rem;
-    column-gap: 20px;
   }
 
   #current-weather-icon {
     width: 2rem;
+  }
+
+  #current-weather-status {
+    margin-left: 20px;
   }
 
   #current-temp {
@@ -700,8 +710,11 @@ body {
   }
 
   #weather-item-list {
-    column-gap: 3.67rem;
     margin-top: 30px;
+  }
+
+  .weather-item + .weather-item {
+    margin-left: 3.67rem;
   }
 
   .weather-item .item-temp-degree {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,0 +1,19 @@
+const gulp = require('gulp')
+const babel = require('gulp-babel')
+const uglifyJS = require('gulp-uglify')
+const uglifyCSS = require('gulp-uglifycss')
+
+function buildJS () {
+  return gulp.src('assets/static/js/*.js')
+    .pipe(babel())
+    .pipe(uglifyJS())
+    .pipe(gulp.dest('assets/static/js'))
+}
+
+function buildCSS () {
+  return gulp.src('assets/static/styles/*.css')
+    .pipe(uglifyCSS())
+    .pipe(gulp.dest('assets/static/styles'))
+}
+
+exports.build = gulp.series(buildJS, buildCSS)

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "test": "jest --verbose",
     "dev": "wrangler dev",
+    "build": "gulp build",
     "deploy": "wrangler publish --env=dev"
   },
   "license": "MIT",
@@ -13,10 +14,16 @@
     "hono": "^2.0.7"
   },
   "devDependencies": {
+    "@babel/core": "^7.19.1",
+    "@babel/preset-env": "^7.19.1",
     "@cloudflare/workers-types": "^3.14.1",
     "@types/jest": "^28.1.6",
     "esbuild": "^0.14.49",
     "esbuild-jest": "^0.5.0",
+    "gulp": "^4.0.2",
+    "gulp-babel": "^8.0.0",
+    "gulp-uglify": "^3.0.2",
+    "gulp-uglifycss": "^1.1.0",
     "jest": "^28.1.3",
     "jest-environment-wrangler": "^0.0.31",
     "wrangler": "^2.0.27"


### PR DESCRIPTION
- Adds babel for transpiling to older ES versions, Closes #26 #27 
- Adds minification Closes #18 

- Updates logic to show current weather

The logic to show the current weather picks up the next slot. So if currently its' 5:45 PM and next slot is 8:30PM, it will show 8:30PM slot as current weather.
The new logic calculates the the time slot that is closest to the current time and shows it as the current.

The limitation being that for the first slot there is no calculation because we don't have slots before that on first load

- Also updates the local weather refresh time (not from the API but the list retrieved originally) to 10 mins from 15 mins.