### PR TITLE
CI: drop push trigger from linter to avoid duplicate runs

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -11,13 +11,10 @@ name: Lint Code Base
 # https://help.github.com/en/articles/workflow-syntax-for-github-actions
 #
 
-#############################
-# Start the job on all push #
-#############################
+###################################
+# Start the job on pull requests   #
+###################################
 on:
-  push:
-    branches-ignore: [master, main]
-    # Remove the line above to run when pushing to master
   pull_request:
     branches: [master, main]
 


### PR DESCRIPTION
## Problem

The lint workflow runs the same job twice for every PR. It triggers on two events that a typical PR satisfies simultaneously:

- `push` — fires on every push to a non-`master`/`main` branch (your feature branch)
- `pull_request` — fires when that branch has an open PR targeting `master`/`main`

So once a PR is open, each push produces both a `(push)` run and a `(pull_request)` run of the identical lint job.

## Fix

Drop the `push` trigger. The workflow now runs only on `pull_request` against `master`/`main`, which is what gates merges anyway — one run per PR push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)