### PR TITLE
Fix stale page cache after deploy (broke observatory redesign on stage)

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -10,6 +10,21 @@ import { trimCoordinates } from './utils'
 
 const app = new Hono()
 
+// A short, deploy-stable token derived from the hashed static-asset manifest.
+// It changes whenever any asset (JS/CSS/font) changes, which is exactly when a
+// deploy ships. Folding it into the page-cache key means a new deploy lands on
+// a fresh key instead of serving a previously cached HTML shell that points at
+// the previous build's assets. Without this, the 12h SSR page cache outlives a
+// deploy and pairs stale HTML with freshly served /static assets.
+const ASSET_VERSION = (() => {
+  const source = typeof manifest === 'string' ? manifest : JSON.stringify(manifest)
+  let hash = 0
+  for (let i = 0; i < source.length; i++) {
+    hash = (Math.imul(31, hash) + source.charCodeAt(i)) | 0
+  }
+  return (hash >>> 0).toString(36)
+})()
+
 app.use('*', logger())
 app.use('/static/*', serveStatic({ root: './', manifest }))
 
@@ -35,8 +50,12 @@ app.get('/', async (c) => {
     })
   } else {
     const cache = caches.default
-    // hono v4's c.req is a HonoRequest wrapper; the Cache API needs the raw Request.
-    const key = c.req.raw
+    // hono v4's c.req is a HonoRequest wrapper; the Cache API needs a raw
+    // Request. Version the key by the deployed asset bundle so each deploy busts
+    // the SSR page cache rather than serving HTML that references stale assets.
+    const keyUrl = new URL(c.req.url)
+    keyUrl.searchParams.set('v', ASSET_VERSION)
+    const key = new Request(keyUrl.toString(), c.req.raw)
     let response = await cache.match(key)
 
     if (!response) {

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -92,6 +92,9 @@ describe('Page caching (/ route)', () => {
     // contract — using c.req would fail this instanceof check.
     expect(keys.length).toBeGreaterThan(0)
     for (const key of keys) expect(key).toBeInstanceOf(Request)
+    // The key must be versioned by the asset bundle so a deploy busts the page
+    // cache instead of serving HTML that references the previous build's assets.
+    for (const key of keys) expect(new URL(key.url).searchParams.get('v')).toBeTruthy()
   })
 
   it('serves the cached page on a repeat request without re-rendering', async () => {


### PR DESCRIPTION
## What broke

PR #55 (observatory redesign) deployed successfully, but `stage-weather.srly.io` rendered broken: stale pre-redesign HTML (old `.header`/`.footer` markup, the removed Barlow font) was served alongside the new observatory CSS/JS.

Root cause is a latent **cache-skew bug** the redesign merely exposed:

- The `/` route server-renders the HTML shell and stores it in `caches.default` for 12h (`s-maxage=43200`), keyed only by request URL.
- That cache **survives across deploys**. `/static` assets are served fresh by `serveStatic`, but the cached HTML shell is never invalidated on deploy.
- So the canonical URL screens hit served old HTML glued to new assets → broken render until the 12h TTL lapsed.

Verified directly: the plain URL returned `cf-cache-status: HIT` with old Barlow markup, while the same URL with a cache-buster rendered the correct `masthead`/`weather-fx`/Fraunces page straight from the worker. The `/api/weather` backend was returning valid data throughout.

This would have bitten **any** markup-changing deploy; the redesign just made it visible.

## Fix

Derive a short token from the hashed static-asset manifest (`ASSET_VERSION`) and fold it into the page-cache key. Asset hashes change on every deploy, so a deploy lands on a fresh key: the stale entry is abandoned and the page re-renders. The intended 12h cache is otherwise preserved.

Once merged and deployed, stage self-heals on the next request (the new asset hash mints a new key) — no manual cache purge needed.

## Testing

- Added a test asserting the page-cache key carries the `v` version token.
- All 22 tests pass; `biome lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)