### PR TITLE
Fix blank stage: build ESM, not IIFE (so the module bundle runs)

### DIFF
--- a/build.js
+++ b/build.js
@@ -23,13 +23,13 @@ for (const { label, glob } of targets) {
       entrypoints: [path],
       minify: true,
       target: 'browser',
-      // main.js is a classic browser IIFE loaded via a plain <script> (no
-      // type="module"). Bun's default 'esm' format rewrites its CommonJS test
-      // hook (module.exports) into an ES module and appends `export default`,
-      // which a classic script cannot parse ("Unexpected token 'export'") so
-      // the whole script fails to run. 'iife' emits a self-contained classic
-      // script with no export. (Ignored for CSS entrypoints.)
-      format: 'iife',
+      // Keep Bun's default 'esm' format. main.js exposes test helpers via
+      // module.exports, so Bun emits it as an ES module ending in `export
+      // default Pq()`, where Pq is the lazy factory wrapping the app's init.
+      // The page loads it with <script type="module">, which both accepts the
+      // `export` and evaluates that statement, invoking Pq() to run the app.
+      // Do NOT switch to format:'iife': it strips the export but never calls
+      // Pq, so the bundle defines everything and runs nothing (blank page).
       // Leave references untouched (e.g. CSS `url(/static/...)` absolute paths)
       // rather than trying to resolve and bundle them as build-time assets.
       external: ['*']


### PR DESCRIPTION
## Why stage is still blank after #57

#57 correctly changed the script tag to `<script type="module">`, but a bad cleanup on my end also merged a `format: 'iife'` change into `build.js`. Combined, they are broken:

- `format: 'iife'` makes Bun emit a bundle that **defines** the lazy module factory `Pq` but **never calls it** (ends in `})();`).
- Loaded as a module, that bundle parses fine — **no console error** — but the app's init never runs. Blank page, no error. Exactly the symptom.

Confirmed against the live deployed bundle: `/static/js/main.js` on stage ends in `})();` with no `export`, i.e. the IIFE build.

## Fix

Remove the `format: 'iife'` line so Bun uses its default ESM output (ends in `export default Pq()`). Loaded via `<script type="module">` the `export` is legal **and** that statement invokes `Pq()`, running the app.

```
-      format: 'iife',
```

Build output, before → after this one line:
- `…})();` (Pq defined, never called → blank)
- `…export default Pq();` (Pq invoked → app runs)

## Verified locally, no deploy

Served the freshly built bundle + the real rendered HTML (`type="module"`) through a harness with a stubbed `/api/weather`, driven by headless Chromium:

- city = **San Francisco**, temp = **55 °F**, scale = **F**, **5** forecast items, **no console errors**.

22 tests pass, `biome lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)