### PR TITLE
Self-healing JS bundle + cache-busted static assets (no purge needed)

### DIFF
--- a/assets/static/js/locale.js
+++ b/assets/static/js/locale.js
@@ -1,0 +1,109 @@
+// Locale, formatting and pure weather helpers, extracted from main.js so they
+// can be unit-tested with a real ES module import. main.js bundles this in at
+// build time; keeping these here (and OUT of main.js's exports) is what lets
+// main.js stay a plain self-executing browser script with no `export` token -
+// see the build note in main.js / Layout.jsx.
+
+/**
+ * Countries / territories using the Fahrenheit scale:
+ * United States (+ territories: Puerto Rico, Guam, US Virgin Islands,
+ * American Samoa, Northern Mariana Islands, US Minor Outlying Islands),
+ * Bahamas, Cayman Islands, Liberia, Palau, Federated States of Micronesia,
+ * Marshall Islands.
+ */
+const countriesUsingFahrenheit = [
+  'US', 'PR', 'GU', 'VI', 'AS', 'MP', 'UM',
+  'BS', 'KY', 'LR', 'PW', 'FM', 'MH'
+]
+
+export const celsiusToFahrenheit = (temp) => ((1.8 * temp) + 32)
+export const usesFahrenheit = (code) => countriesUsingFahrenheit.includes(code)
+
+const locales = JSON.parse('{"AF":"ps-AF","AL":"sq-AL","DZ":"ar-DZ","AS":"en-AS","AD":"ca","AO":"pt","AI":"en","AQ":"en-US","AG":"en","AR":"es-AR","AM":"hy-AM","AW":"nl","AU":"en-AU","AT":"de-AT","AZ":"az-Cyrl-AZ","BS":"en","BH":"ar-BH","BD":"bn-BD","BB":"en","BY":"be-BY","BE":"nl-BE","BZ":"en-BZ","BJ":"fr-BJ","BM":"en","BT":"dz","BO":"es-BO","BQ":"nl","BA":"bs-BA","BW":"en-BW","BV":"no","BR":"pt-BR","IO":"en","BN":"ms-BN","BG":"bg-BG","BF":"fr-BF","BI":"fr-BI","CV":"kea-CV","KH":"km-KH","CM":"fr-CM","CA":"en-CA","KY":"en","CF":"fr-CF","TD":"fr-TD","CL":"es-CL","CN":"zh-CN","CX":"en","CC":"en","CO":"es-CO","KM":"fr-KM","CD":"fr-CD","CG":"fr-CG","CK":"en","CR":"es-CR","HR":"hr-HR","CU":"es","CW":"nl","CY":"el-CY","CZ":"cs-CZ","CI":"fr-CI","DK":"da-DK","DJ":"fr-DJ","DM":"en","DO":"es-DO","EC":"es-EC","EG":"ar-EG","SV":"es-SV","GQ":"fr-GQ","ER":"ti-ER","EE":"et-EE","SZ":"en","ET":"am-ET","FK":"en","FO":"fo-FO","FJ":"en","FI":"fi-FI","FR":"fr-FR","GF":"fr","PF":"fr","TF":"fr","GA":"fr-GA","GM":"en","GE":"ka-GE","DE":"de-DE","GH":"ak-GH","GI":"en","GR":"el-GR","GL":"kl-GL","GD":"en","GP":"fr-GP","GU":"en-GU","GT":"es-GT","GG":"en","GN":"fr-GN","GW":"pt-GW","GY":"en","HT":"fr","HM":"en","VA":"it","HN":"es-HN","HK":"en-HK","HU":"hu-HU","IS":"is-IS","IN":"hi-IN","ID":"id-ID","IR":"fa-IR","IQ":"ar-IQ","IE":"en-IE","IM":"en","IL":"he-IL","IT":"it-IT","JM":"en-JM","JP":"ja-JP","JE":"en","JO":"ar-JO","KZ":"kk-Cyrl-KZ","KE":"ebu-KE","KI":"en","KP":"ko","KR":"ko-KR","KW":"ar-KW","KG":"ky","LA":"lo","LV":"lv-LV","LB":"ar-LB","LS":"en","LR":"en","LY":"ar-LY","LI":"de-LI","LT":"lt-LT","LU":"fr-LU","MO":"zh-Hans-MO","MG":"fr-MG","MW":"en","MY":"ms-MY","MV":"dv","ML":"fr-ML","MT":"en-MT","MH":"en-MH","MQ":"fr-MQ","MR":"ar","MU":"en-MU","YT":"fr","MX":"es-MX","FM":"en","MD":"ro-MD","MC":"fr-MC","MN":"mn","ME":"sr-Cyrl-ME","MS":"en","MA":"ar-MA","MZ":"pt-MZ","MM":"my-MM","NA":"en-NA","NR":"en","NP":"ne-NP","NL":"nl-NL","AN":"nl-AN","NC":"fr","NZ":"en-NZ","NI":"es-NI","NE":"fr-NE","NG":"ha-Latn-NG","NU":"en","NF":"en","MK":"mk-MK","MP":"en-MP","NO":"nb-NO","OM":"ar-OM","PK":"en-PK","PW":"en","PS":"ar","PA":"es-PA","PG":"en","PY":"es-PY","PE":"es-PE","PH":"en-PH","PN":"en","PL":"pl-PL","PT":"pt-PT","PR":"es-PR","QA":"ar-QA","RO":"ro-RO","RU":"ru-RU","RW":"fr-RW","RE":"fr-RE","BL":"fr-BL","SH":"en","KN":"en","LC":"en","MF":"fr-MF","PM":"fr","VC":"en","WS":"sm","SM":"it","ST":"pt","SA":"ar-SA","SN":"fr-SN","RS":"sr-Cyrl-RS","SC":"fr","SL":"en","SG":"en-SG","SX":"nl","SK":"sk-SK","SI":"sl-SI","SB":"en","SO":"so-SO","ZA":"af-ZA","GS":"en","SS":"en","ES":"es-ES","LK":"si-LK","SD":"ar-SD","SR":"nl","SJ":"no","SE":"sv-SE","CH":"fr-CH","SY":"ar-SY","TW":"zh-Hant-TW","TJ":"tg","TZ":"asa-TZ","TH":"th-TH","TL":"pt","TG":"fr-TG","TK":"en","TO":"to-TO","TT":"en-TT","TN":"ar-TN","TR":"tr-TR","TM":"tk","TC":"en","TV":"en","UG":"cgg-UG","UA":"uk-UA","AE":"ar-AE","GB":"en-GB","UM":"en-UM","US":"en-US","UY":"es-UY","UZ":"uz-Cyrl-UZ","VU":"bi","VE":"es-VE","VN":"vi-VN","VG":"en","VI":"en-VI","WF":"fr","EH":"es","YE":"ar-YE","ZM":"bem-ZM","ZW":"en-ZW","AX":"sv","XK":"sq"}')
+
+// Default locale when the country is unknown. en-GB gives 24h time and
+// neutral English month/day names (better for signage than the player's
+// own device locale, which is effectively random).
+const FALLBACK_LOCALE = 'en-GB'
+
+// Right-to-left primary language subtags that appear in the locale map.
+const rtlLanguages = ['ar', 'fa', 'he', 'ps', 'dv', 'ur', 'ckb', 'sd', 'yi']
+
+// BCP-47 locale for the displayed location, plus cached Intl formatters.
+let locale = 'en-GB'
+let timeFormatter
+let dateFormatterLong
+let dateFormatterShort
+
+const buildFormatters = () => {
+  // Pin the Gregorian calendar so the date always matches the (Gregorian)
+  // forecast — otherwise locales like ar-SA would render a Hijri date.
+  // Names, ordering and numerals stay localized.
+  const timeOpts = { hour: 'numeric', minute: '2-digit' }
+  const dateLongOpts = { weekday: 'long', month: 'short', day: 'numeric', calendar: 'gregory' }
+  const dateShortOpts = { weekday: 'short', month: 'short', day: 'numeric', calendar: 'gregory' }
+  try {
+    // Intl picks 12h vs 24h, localized month/day names and AM/PM per locale.
+    timeFormatter = new Intl.DateTimeFormat(locale, timeOpts)
+    dateFormatterLong = new Intl.DateTimeFormat(locale, dateLongOpts)
+    dateFormatterShort = new Intl.DateTimeFormat(locale, dateShortOpts)
+  } catch {
+    // Malformed locale string: fall back rather than break the clock.
+    locale = FALLBACK_LOCALE
+    timeFormatter = new Intl.DateTimeFormat(locale, timeOpts)
+    dateFormatterLong = new Intl.DateTimeFormat(locale, dateLongOpts)
+    dateFormatterShort = new Intl.DateTimeFormat(locale, dateShortOpts)
+  }
+}
+
+export const resolveLocale = (code) => locales[code] || FALLBACK_LOCALE
+
+export const setLocale = (code) => {
+  locale = resolveLocale(code)
+  buildFormatters()
+  // The chrome is authored in English (LTR); only the city, date and time
+  // render in the location's language. Tag just those elements with the right
+  // lang/dir so assistive tech and RTL scripts (e.g. ar) are handled without
+  // mirroring the whole LTR layout.
+  if (typeof document !== 'undefined') {
+    const dir = rtlLanguages.includes(locale.split('-')[0]) ? 'rtl' : 'ltr'
+    for (const id of ['city', 'date', 'time']) {
+      const el = document.querySelector(`#${id}`)
+      if (el) {
+        el.lang = locale
+        el.dir = dir
+      }
+    }
+  }
+}
+
+// Build defaults up front so the clock works even before any data arrives.
+buildFormatters()
+
+export const getTimeByOffset = (offsetinSecs, dt) => {
+  const now = dt ? new Date(dt * 1000) : new Date()
+  const utc = now.getTime() + (now.getTimezoneOffset() * 60 * 1000)
+  return new Date(utc + (offsetinSecs * 1000))
+}
+
+// getTimeByOffset returns a Date whose *local-time* components already read
+// as the location's wall clock, so the default-timezone Intl formatters
+// (which read the same local components) render the correct local time/date.
+export const formatTime = (dateObj) => timeFormatter.format(dateObj)
+
+export const formatDate = (dateObj) => {
+  const wide = typeof window === 'undefined' || window.innerWidth >= 480
+  const formatter = wide ? dateFormatterLong : dateFormatterShort
+  return formatter.format(dateObj)
+}
+
+// Simplified condition category used to drive the weather-reactive accent.
+export const getCondCategory = (id) => {
+  if (id >= 200 && id <= 299) return 'thunderstorm'
+  if (id >= 300 && id <= 399) return 'drizzle'
+  if (id >= 500 && id <= 599) return 'rain'
+  if (id >= 600 && id <= 699) return 'snow'
+  if (id >= 700 && id <= 799) return 'haze'
+  if (id === 800) return 'clear'
+  return 'clouds'
+}

--- a/assets/static/js/main.js
+++ b/assets/static/js/main.js
@@ -1,4 +1,19 @@
-/* global module */
+import {
+  usesFahrenheit,
+  celsiusToFahrenheit,
+  setLocale,
+  getTimeByOffset,
+  formatTime,
+  formatDate,
+  getCondCategory
+} from './locale.js'
+
+// This file is bundled by Bun.build and served as a PLAIN classic <script>.
+// It must therefore stay a self-executing IIFE with NO top-level `export`:
+// the testable helpers live in ./locale.js (bundled in here), and this file
+// exports nothing. That keeps the served bundle loadable by every cached HTML
+// variant — both the old classic <script> tag and a type="module" tag run a
+// self-executing script identically — so a deploy never strands cached pages.
 (() => {
   let clockTimer
   let weatherTimer
@@ -7,97 +22,24 @@
   let tz
   let currentWeatherId
   let tempScale = 'C'
-  // BCP-47 locale for the displayed location, plus cached Intl formatters.
-  let locale = 'en-GB'
-  let timeFormatter
-  let dateFormatterLong
-  let dateFormatterShort
 
   const imagesPath = '/static/images'
   const iconsPath = `${imagesPath}/icons`
   const bgPath = `${imagesPath}/bg`
 
-  /**
-   * Countries / territories using the Fahrenheit scale:
-   * United States (+ territories: Puerto Rico, Guam, US Virgin Islands,
-   * American Samoa, Northern Mariana Islands, US Minor Outlying Islands),
-   * Bahamas, Cayman Islands, Liberia, Palau, Federated States of Micronesia,
-   * Marshall Islands.
-   */
-
-  const countriesUsingFahrenheit = [
-    'US', 'PR', 'GU', 'VI', 'AS', 'MP', 'UM',
-    'BS', 'KY', 'LR', 'PW', 'FM', 'MH'
-  ]
-  const celsiusToFahrenheit = (temp) => ((1.8 * temp) + 32)
-  const usesFahrenheit = (code) => countriesUsingFahrenheit.includes(code)
+  // Cache-busting suffix for JS-built asset URLs (icons, backgrounds). The
+  // version is injected by the page as window.__ASSET_V; absent it (e.g. an
+  // old cached page), URLs stay unversioned and still resolve.
+  const assetVersion = (typeof window !== 'undefined' && window.__ASSET_V) || ''
+  const withVersion = (url) => (assetVersion ? `${url}?v=${assetVersion}` : url)
 
   const getTemp = (temp) => Math.round(tempScale === 'C' ? temp : celsiusToFahrenheit(temp))
+
   /**
    * Utility Functions
    */
   const generateAnalyticsEvent = (name, payload) => {
     typeof gtag !== 'undefined' && gtag('event', name, payload) // eslint-disable-line no-undef
-  }
-
-  const locales = JSON.parse('{"AF":"ps-AF","AL":"sq-AL","DZ":"ar-DZ","AS":"en-AS","AD":"ca","AO":"pt","AI":"en","AQ":"en-US","AG":"en","AR":"es-AR","AM":"hy-AM","AW":"nl","AU":"en-AU","AT":"de-AT","AZ":"az-Cyrl-AZ","BS":"en","BH":"ar-BH","BD":"bn-BD","BB":"en","BY":"be-BY","BE":"nl-BE","BZ":"en-BZ","BJ":"fr-BJ","BM":"en","BT":"dz","BO":"es-BO","BQ":"nl","BA":"bs-BA","BW":"en-BW","BV":"no","BR":"pt-BR","IO":"en","BN":"ms-BN","BG":"bg-BG","BF":"fr-BF","BI":"fr-BI","CV":"kea-CV","KH":"km-KH","CM":"fr-CM","CA":"en-CA","KY":"en","CF":"fr-CF","TD":"fr-TD","CL":"es-CL","CN":"zh-CN","CX":"en","CC":"en","CO":"es-CO","KM":"fr-KM","CD":"fr-CD","CG":"fr-CG","CK":"en","CR":"es-CR","HR":"hr-HR","CU":"es","CW":"nl","CY":"el-CY","CZ":"cs-CZ","CI":"fr-CI","DK":"da-DK","DJ":"fr-DJ","DM":"en","DO":"es-DO","EC":"es-EC","EG":"ar-EG","SV":"es-SV","GQ":"fr-GQ","ER":"ti-ER","EE":"et-EE","SZ":"en","ET":"am-ET","FK":"en","FO":"fo-FO","FJ":"en","FI":"fi-FI","FR":"fr-FR","GF":"fr","PF":"fr","TF":"fr","GA":"fr-GA","GM":"en","GE":"ka-GE","DE":"de-DE","GH":"ak-GH","GI":"en","GR":"el-GR","GL":"kl-GL","GD":"en","GP":"fr-GP","GU":"en-GU","GT":"es-GT","GG":"en","GN":"fr-GN","GW":"pt-GW","GY":"en","HT":"fr","HM":"en","VA":"it","HN":"es-HN","HK":"en-HK","HU":"hu-HU","IS":"is-IS","IN":"hi-IN","ID":"id-ID","IR":"fa-IR","IQ":"ar-IQ","IE":"en-IE","IM":"en","IL":"he-IL","IT":"it-IT","JM":"en-JM","JP":"ja-JP","JE":"en","JO":"ar-JO","KZ":"kk-Cyrl-KZ","KE":"ebu-KE","KI":"en","KP":"ko","KR":"ko-KR","KW":"ar-KW","KG":"ky","LA":"lo","LV":"lv-LV","LB":"ar-LB","LS":"en","LR":"en","LY":"ar-LY","LI":"de-LI","LT":"lt-LT","LU":"fr-LU","MO":"zh-Hans-MO","MG":"fr-MG","MW":"en","MY":"ms-MY","MV":"dv","ML":"fr-ML","MT":"en-MT","MH":"en-MH","MQ":"fr-MQ","MR":"ar","MU":"en-MU","YT":"fr","MX":"es-MX","FM":"en","MD":"ro-MD","MC":"fr-MC","MN":"mn","ME":"sr-Cyrl-ME","MS":"en","MA":"ar-MA","MZ":"pt-MZ","MM":"my-MM","NA":"en-NA","NR":"en","NP":"ne-NP","NL":"nl-NL","AN":"nl-AN","NC":"fr","NZ":"en-NZ","NI":"es-NI","NE":"fr-NE","NG":"ha-Latn-NG","NU":"en","NF":"en","MK":"mk-MK","MP":"en-MP","NO":"nb-NO","OM":"ar-OM","PK":"en-PK","PW":"en","PS":"ar","PA":"es-PA","PG":"en","PY":"es-PY","PE":"es-PE","PH":"en-PH","PN":"en","PL":"pl-PL","PT":"pt-PT","PR":"es-PR","QA":"ar-QA","RO":"ro-RO","RU":"ru-RU","RW":"fr-RW","RE":"fr-RE","BL":"fr-BL","SH":"en","KN":"en","LC":"en","MF":"fr-MF","PM":"fr","VC":"en","WS":"sm","SM":"it","ST":"pt","SA":"ar-SA","SN":"fr-SN","RS":"sr-Cyrl-RS","SC":"fr","SL":"en","SG":"en-SG","SX":"nl","SK":"sk-SK","SI":"sl-SI","SB":"en","SO":"so-SO","ZA":"af-ZA","GS":"en","SS":"en","ES":"es-ES","LK":"si-LK","SD":"ar-SD","SR":"nl","SJ":"no","SE":"sv-SE","CH":"fr-CH","SY":"ar-SY","TW":"zh-Hant-TW","TJ":"tg","TZ":"asa-TZ","TH":"th-TH","TL":"pt","TG":"fr-TG","TK":"en","TO":"to-TO","TT":"en-TT","TN":"ar-TN","TR":"tr-TR","TM":"tk","TC":"en","TV":"en","UG":"cgg-UG","UA":"uk-UA","AE":"ar-AE","GB":"en-GB","UM":"en-UM","US":"en-US","UY":"es-UY","UZ":"uz-Cyrl-UZ","VU":"bi","VE":"es-VE","VN":"vi-VN","VG":"en","VI":"en-VI","WF":"fr","EH":"es","YE":"ar-YE","ZM":"bem-ZM","ZW":"en-ZW","AX":"sv","XK":"sq"}')
-  // Default locale when the country is unknown. en-GB gives 24h time and
-  // neutral English month/day names (better for signage than the player's
-  // own device locale, which is effectively random).
-  const FALLBACK_LOCALE = 'en-GB'
-
-  // Right-to-left primary language subtags that appear in the locale map.
-  const rtlLanguages = ['ar', 'fa', 'he', 'ps', 'dv', 'ur', 'ckb', 'sd', 'yi']
-
-  const buildFormatters = () => {
-    // Pin the Gregorian calendar so the date always matches the (Gregorian)
-    // forecast — otherwise locales like ar-SA would render a Hijri date.
-    // Names, ordering and numerals stay localized.
-    const timeOpts = { hour: 'numeric', minute: '2-digit' }
-    const dateLongOpts = { weekday: 'long', month: 'short', day: 'numeric', calendar: 'gregory' }
-    const dateShortOpts = { weekday: 'short', month: 'short', day: 'numeric', calendar: 'gregory' }
-    try {
-      // Intl picks 12h vs 24h, localized month/day names and AM/PM per locale.
-      timeFormatter = new Intl.DateTimeFormat(locale, timeOpts)
-      dateFormatterLong = new Intl.DateTimeFormat(locale, dateLongOpts)
-      dateFormatterShort = new Intl.DateTimeFormat(locale, dateShortOpts)
-    } catch {
-      // Malformed locale string: fall back rather than break the clock.
-      locale = FALLBACK_LOCALE
-      timeFormatter = new Intl.DateTimeFormat(locale, timeOpts)
-      dateFormatterLong = new Intl.DateTimeFormat(locale, dateLongOpts)
-      dateFormatterShort = new Intl.DateTimeFormat(locale, dateShortOpts)
-    }
-  }
-
-  const resolveLocale = (code) => locales[code] || FALLBACK_LOCALE
-
-  const setLocale = (code) => {
-    locale = resolveLocale(code)
-    buildFormatters()
-    // The chrome is authored in English (LTR); only the city, date and time
-    // render in the location's language. Tag just those elements with the right
-    // lang/dir so assistive tech and RTL scripts (e.g. ar) are handled without
-    // mirroring the whole LTR layout.
-    if (typeof document !== 'undefined') {
-      const dir = rtlLanguages.includes(locale.split('-')[0]) ? 'rtl' : 'ltr'
-      for (const id of ['city', 'date', 'time']) {
-        const el = document.querySelector(`#${id}`)
-        if (el) {
-          el.lang = locale
-          el.dir = dir
-        }
-      }
-    }
-  }
-
-  // Build defaults up front so the clock works even before any data arrives.
-  buildFormatters()
-
-  const getTimeByOffset = (offsetinSecs, dt) => {
-    const now = dt ? new Date(dt * 1000) : new Date()
-    const utc = now.getTime() + (now.getTimezoneOffset() * 60 * 1000)
-    return new Date(utc + (offsetinSecs * 1000))
   }
 
   const checkIfNight = (dt) => {
@@ -114,8 +56,8 @@
   const updateAttribute = (id, attr, val) => document.querySelector(`#${id}`).setAttribute(attr, val)
 
   const loadImage = (img = 'default') => {
-    const lowResImgSrc = `${bgPath}/${img}-min.jpg`
-    const highResImgSrc = `${bgPath}/${img}.jpg`
+    const lowResImgSrc = withVersion(`${bgPath}/${img}-min.jpg`)
+    const highResImgSrc = withVersion(`${bgPath}/${img}.jpg`)
 
     const lowResImage = new Image()
     const highResImage = new Image()
@@ -203,21 +145,6 @@
     }
   }
 
-  /**
-   * Update Local Time and Date
-   */
-
-  // getTimeByOffset returns a Date whose *local-time* components already read
-  // as the location's wall clock, so the default-timezone Intl formatters
-  // (which read the same local components) render the correct local time/date.
-  const formatTime = (dateObj) => timeFormatter.format(dateObj)
-
-  const formatDate = (dateObj) => {
-    const wide = typeof window === 'undefined' || window.innerWidth >= 480
-    const formatter = wide ? dateFormatterLong : dateFormatterShort
-    return formatter.format(dateObj)
-  }
-
   const initDateTime = (tzOffset) => {
     tz = tzOffset
     clearTimeout(clockTimer)
@@ -245,22 +172,11 @@
   }
 
   const updateCurrentWeather = (icon, desc, temp) => {
-    updateAttribute('current-weather-icon', 'src', `${iconsPath}/${icon}.svg`)
+    updateAttribute('current-weather-icon', 'src', withVersion(`${iconsPath}/${icon}.svg`))
     updateContent('current-weather-status', desc)
     updateContent('current-temp', getTemp(temp))
     // The degree sign is a static element; the scale element holds just C/F.
     updateContent('current-temp-scale', tempScale)
-  }
-
-  // Simplified condition category used to drive the weather-reactive accent.
-  const getCondCategory = (id) => {
-    if (id >= 200 && id <= 299) return 'thunderstorm'
-    if (id >= 300 && id <= 399) return 'drizzle'
-    if (id >= 500 && id <= 599) return 'rain'
-    if (id >= 600 && id <= 699) return 'snow'
-    if (id >= 700 && id <= 799) return 'haze'
-    if (id === 800) return 'clear'
-    return 'clouds'
   }
 
   const setAccent = (id, dt) => {
@@ -350,7 +266,7 @@
       const node = dummyNode.cloneNode(true)
       node.classList.remove('dummy-node')
       node.querySelector('.item-temp').textContent = getTemp(temp)
-      node.querySelector('.item-icon').setAttribute('src', `${iconsPath}/${icon}.svg`)
+      node.querySelector('.item-icon').setAttribute('src', withVersion(`${iconsPath}/${icon}.svg`))
       node.querySelector('.item-time').textContent = index === 0 ? 'Current' : formatTime(dateTime)
 
       frag.appendChild(node)
@@ -465,20 +381,6 @@
       document.addEventListener('DOMContentLoaded', init)
     } else {
       init()
-    }
-  }
-
-  // Expose pure helpers for unit tests. In the browser `module` is undefined,
-  // so this is skipped and has no effect on the served script.
-  if (typeof module !== 'undefined' && module.exports) {
-    module.exports = {
-      resolveLocale,
-      usesFahrenheit,
-      setLocale,
-      formatTime,
-      formatDate,
-      getTimeByOffset,
-      getCondCategory
     }
   }
 })()

--- a/build.js
+++ b/build.js
@@ -10,29 +10,34 @@ import { run as syncFonts } from './sync-fonts.js'
 // Vendor the Bun-managed webfonts into ./assets before minifying.
 await syncFonts()
 
+// main.js is the only JS *entry*. It imports ./locale.js (the unit-tested pure
+// helpers), and `external: []` tells Bun to inline that import. main.js itself
+// exports nothing, so the bundle is a self-executing classic script with no
+// `export` token — loadable by every cached HTML variant (plain <script> or
+// type="module") so a deploy never strands cached pages. locale.js is a
+// dependency, not an entry, so it is never built/served on its own.
+const cssEntries = []
+for await (const path of new Glob('assets/static/styles/*.css').scan('.')) {
+  cssEntries.push(path)
+}
+
 const targets = [
-  { label: 'JS', glob: 'assets/static/js/*.js' },
-  { label: 'CSS', glob: 'assets/static/styles/*.css' }
+  // Bundle local imports (external: []).
+  { label: 'JS', entries: ['assets/static/js/main.js'], external: [] },
+  // Leave url(/static/...) refs untouched rather than resolving them as
+  // build-time assets (external: ['*']).
+  { label: 'CSS', entries: cssEntries, external: ['*'] }
 ]
 
 let count = 0
 
-for (const { label, glob } of targets) {
-  for await (const path of new Glob(glob).scan('.')) {
+for (const { label, entries, external } of targets) {
+  for (const path of entries) {
     const result = await Bun.build({
       entrypoints: [path],
       minify: true,
       target: 'browser',
-      // Keep Bun's default 'esm' format. main.js exposes test helpers via
-      // module.exports, so Bun emits it as an ES module ending in `export
-      // default Pq()`, where Pq is the lazy factory wrapping the app's init.
-      // The page loads it with <script type="module">, which both accepts the
-      // `export` and evaluates that statement, invoking Pq() to run the app.
-      // Do NOT switch to format:'iife': it strips the export but never calls
-      // Pq, so the bundle defines everything and runs nothing (blank page).
-      // Leave references untouched (e.g. CSS `url(/static/...)` absolute paths)
-      // rather than trying to resolve and bundle them as build-time assets.
-      external: ['*']
+      external
     })
 
     if (!result.success) {

--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -9,17 +9,17 @@ import { sentryIds, gaIds } from '../constants'
 const FX_PARTICLES = 30
 
 const App = (props) => {
-  const { env, lat, lng } = props
+  const { env, lat, lng, v } = props
   const sentryId = sentryIds[env]
   const gaId = gaIds[env]
   return (
-    <Layout sentryId={sentryId} gaId={gaId}>
+    <Layout sentryId={sentryId} gaId={gaId} v={v}>
       <div class='content playing'>
         <div class='weather-fx' aria-hidden='true'>
           {Array.from({ length: FX_PARTICLES }).map(() => <span class='fx-p' />)}
         </div>
-        <Header />
-        <Footer />
+        <Header v={v} />
+        <Footer v={v} />
       </div>
       <span id='location-data' data-location-lat={lat} data-location-lng={lng} />
     </Layout>

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -1,6 +1,6 @@
 import { html } from 'hono/html'
 
-const Footer = () => html`
+const Footer = (props) => html`
   <div class="midrow">
     <section class="hero">
       <div class="weather-condition anim" style="--d: 260ms">
@@ -19,7 +19,7 @@ const Footer = () => html`
       <div class="upgrade-banner">
         <span class="cta-msg" id="cta-msg">Powerful, secure, simple digital signage</span>
         <span class="cta-lockup">
-          <img class="cta-logo" src="/static/images/screenly-logo.svg" alt="Screenly" width="178" height="40" />
+          <img class="cta-logo" src="/static/images/screenly-logo.svg?v=${props.v}" alt="Screenly" width="178" height="40" />
           <span class="cta-url">screenly.io</span>
         </span>
       </div>

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,9 +1,9 @@
 import { html } from 'hono/html'
 
-const Header = () => html`
+const Header = (props) => html`
   <header class="masthead">
     <span class="place anim" style="--d: 0ms">
-      <img src="/static/images/icons/map-pin.svg" alt="" width="24" height="24" />
+      <img src="/static/images/icons/map-pin.svg?v=${props.v}" alt="" width="24" height="24" />
       <span id="city"></span>
     </span>
     <span class="clock anim" style="--d: 80ms">

--- a/src/components/Layout.jsx
+++ b/src/components/Layout.jsx
@@ -7,19 +7,22 @@ const Layout = (props) => html`<!DOCTYPE html>
       <meta name="viewport" content="width=device-width, initial-scale=1.0">
       <link
         rel="preload"
-        href="/static/fonts/fraunces-latin-standard-normal.woff2"
+        href="/static/fonts/fraunces-latin-standard-normal.woff2?v=${props.v}"
         as="font"
         type="font/woff2"
         crossorigin
       />
       <link
         rel="preload"
-        href="/static/fonts/hanken-grotesk-latin-wght-normal.woff2"
+        href="/static/fonts/hanken-grotesk-latin-wght-normal.woff2?v=${props.v}"
         as="font"
         type="font/woff2"
         crossorigin
       />
-      <link rel="stylesheet" href="/static/styles/main.css" />
+      <link rel="stylesheet" href="/static/styles/main.css?v=${props.v}" />
+      <!-- Expose the asset version so main.js can cache-bust the image URLs it
+           builds at runtime (weather icons, backgrounds). -->
+      <script>window.__ASSET_V='${props.v}'</script>
       <script
         src="https://js.sentry-cdn.com/${props.sentryId}.min.js"
         crossorigin="anonymous"
@@ -33,16 +36,10 @@ const Layout = (props) => html`<!DOCTYPE html>
 
         gtag('config', '${props.gaId}');
       </script>
-      <!--
-        main.js is bundled by Bun.build, which detects its module.exports test
-        hook and emits an ES module (the bundle ends in \`export default ...\`).
-        It must therefore be loaded as type="module": a classic script cannot
-        contain \`export\` ("Unexpected token 'export'") and, even stripped of
-        the error, the lazy module factory would never be invoked. Loading it as
-        a module both parses the export and evaluates the factory, running the
-        app. Module scripts are deferred by default, so the DOM is ready.
-      -->
-      <script type="module" src="/static/js/main.js"></script>
+      <!-- main.js is a self-executing classic script (no ES module export), so
+           a plain async <script> runs it and any cached HTML stays compatible
+           across deploys. The ?v= busts it whenever the bundle changes. -->
+      <script src="/static/js/main.js?v=${props.v}" async defer></script>
     </head>
     <body>
       ${props.children}

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -26,6 +26,19 @@ const ASSET_VERSION = (() => {
 })()
 
 app.use('*', logger())
+
+// Cache headers for static assets. Asset URLs in the HTML carry ?v=<version>
+// (see ASSET_VERSION / the components), so a versioned request is safe to cache
+// forever — a content change ships a new ?v and therefore a new URL. Legacy
+// unversioned URLs (only referenced by pre-cache-busting HTML still sitting in
+// the edge cache) get a short TTL so they can pick up the current bundle.
+app.use('/static/*', async (c, next) => {
+  await next()
+  const versioned = c.req.query('v') !== undefined
+  c.header('Cache-Control', versioned
+    ? 'public, max-age=31536000, immutable'
+    : 'public, max-age=300')
+})
 app.use('/static/*', serveStatic({ root: './', manifest }))
 
 app.get('/', async (c) => {
@@ -61,7 +74,7 @@ app.get('/', async (c) => {
     if (!response) {
       const coordinates = trimCoordinates({ lat: qLat, lng: qLng })
       const env = c.env.ENV
-      const body = (<App {...coordinates} env={env} />).toString()
+      const body = (<App {...coordinates} env={env} v={ASSET_VERSION} />).toString()
       response = new Response(body, {
         status: 200,
         headers: {

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -60,15 +60,17 @@ describe('Routing', () => {
 
   it('renders the page HTML via hono JSX (server-side)', () => {
     // Mirrors the route's `new Response((<App/>).toString())`.
-    const body = jsx(App, { env: 'production', lat: '51.5', lng: '-0.12' }).toString()
+    const body = jsx(App, { env: 'production', lat: '51.5', lng: '-0.12', v: 'testver' }).toString()
     expect(body).toContain('<!DOCTYPE html>')
     expect(body).toContain('id="weather-item-list"')
     expect(body).toContain('weather-fx')
     expect(body).not.toContain('[object Object]')
-    // main.js is bundled as an ES module (ends in `export default`), so it must
-    // be loaded as a module or the browser throws on the `export` token and the
-    // page never populates.
-    expect(body).toContain('<script type="module" src="/static/js/main.js">')
+    // main.js is a self-executing classic script (no ES module export), loaded
+    // via a plain async <script> so cached HTML stays compatible across deploys.
+    expect(body).toContain('<script src="/static/js/main.js?v=testver" async defer>')
+    // Static asset URLs are cache-busted with the deploy version.
+    expect(body).toContain('/static/styles/main.css?v=testver')
+    expect(body).toContain("window.__ASSET_V='testver'")
   })
 })
 
@@ -110,6 +112,19 @@ describe('Page caching (/ route)', () => {
 
     expect(res.status).toBe(200)
     expect(await res.text()).toBe('CACHED PAGE')
+  })
+})
+
+describe('Static asset caching (/static/*)', () => {
+  it('caches versioned assets immutably and unversioned ones briefly', async () => {
+    // Versioned URL (?v=...) is content-addressed via the query, so it is safe
+    // to cache forever; the unversioned legacy URL must stay short-lived so old
+    // cached HTML can pick up the current bundle.
+    const versioned = await app.request('http://localhost/static/js/main.js?v=abc')
+    expect(versioned.headers.get('Cache-Control')).toBe('public, max-age=31536000, immutable')
+
+    const unversioned = await app.request('http://localhost/static/js/main.js')
+    expect(unversioned.headers.get('Cache-Control')).toBe('public, max-age=300')
   })
 })
 

--- a/test/locale.test.js
+++ b/test/locale.test.js
@@ -1,12 +1,10 @@
 import { describe, expect, it } from 'bun:test'
 
-// Unit tests for the client-side locale logic in assets/static/js/main.js.
-// main.js is a browser IIFE that exposes its pure helpers via module.exports
-// (and skips its browser-only init when there is no document), so a default
-// import here resolves to that exports object.
-import main from '../assets/static/js/main.js'
-
-const {
+// Unit tests for the client-side locale logic in assets/static/js/locale.js.
+// These pure helpers were extracted from main.js into their own ES module so
+// they can be imported directly here, while main.js stays an export-free
+// self-executing browser script (bundled with locale.js inlined).
+import {
   resolveLocale,
   usesFahrenheit,
   setLocale,
@@ -14,7 +12,7 @@ const {
   formatDate,
   getTimeByOffset,
   getCondCategory
-} = main
+} from '../assets/static/js/locale.js'
 
 // Saturday 2026-06-20 13:30:00 UTC, as the unix seconds main.js works with.
 const DT = Math.floor(Date.parse('2026-06-20T13:30:00Z') / 1000)


### PR DESCRIPTION
Closes out the blank-page incidents at the root and removes any need to **Purge Everything** (untenable at our traffic — it would stampede the worker and OpenWeather).

## Two root problems

1. **ESM bundle loaded by stale classic-tag HTML.** `/static/js/main.js` was built as an ES module (`export default …`). Cloudflare's edge still serves pre-fix HTML carrying the old classic `<script>` tag, which loads the ESM bundle as a classic script → `Unexpected token 'export'` → blank. Any fix that only changes the HTML tag never reaches those cached pages, and we can't purge them.
2. **Unversioned asset URLs.** HTML and JS/CSS were cached on independent lifetimes at stable URLs, so they drift out of sync.

## Changes

- **Self-healing bundle.** Extracted the unit-tested pure helpers into `assets/static/js/locale.js` and bundle them into `main.js`, so `main.js` has **no `export`** and Bun emits a **self-executing classic IIFE**. Since `/static/js/main.js` is stable and not long-cached, *every* cached HTML variant — old classic-`<script>` pages and `type="module"` pages — runs it identically. **Stale pages self-heal on next view: no purge, no stampede.**
- Reverted the script tag to a plain `async` `<script>`.
- **Cache-busting on all static assets** via `?v=<ASSET_VERSION>`: CSS, font preloads, template images, the bundle, and the icon/background URLs `main.js` builds at runtime (through `window.__ASSET_V`). Versioned `/static/*` responses are `public, max-age=31536000, immutable`; unversioned legacy URLs keep `max-age=300` so still-cached pages pick up the current bundle.

## How the fleet recovers without a purge

The poisoned thing is the cached HTML's classic `<script>` + an ESM bundle. This PR makes the bundle a classic self-executing script, so that exact cached HTML now *works*. Each device heals on its next load as it re-fetches the (short-TTL) bundle. No URL enumeration, no Purge Everything.

## Verification (headless browser, freshly built bundle)

| Page | Console | Result |
|---|---|---|
| Simulated **stale cached** page (classic tag, no version) | none | populates — San Francisco, 55°F, 5-item forecast |
| New **versioned** page | none | populates; runtime image URLs carry `?v=` |

23 tests pass, `biome lint` clean.

> Note: `/api/weather` caching is untouched. No cache purge required to deploy this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)