### PR TITLE
Add Cloudflare GeoIP to the location fallback chain

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -46,11 +46,16 @@ app.get('/', async (c) => {
   const qLng = c.req.query(locationQueryParams.lng)
 
   // Redirect to a canonical URL whenever either coordinate is missing, filling
-  // gaps from the Screenly location headers or the default location, so the
-  // render path always has both lat and lng.
+  // gaps so the render path always has both lat and lng. Resolution order, most
+  // to least specific: explicit query params > the Screenly player's
+  // asset-metadata headers > Cloudflare's request IP geolocation > the default.
+  // The GeoIP step (request.cf, populated by the Workers runtime at the edge)
+  // means browser/no-header traffic lands on the viewer's approximate location
+  // instead of always defaulting to San Francisco.
   if (!qLat || !qLng) {
-    const lat = qLat || c.req.header(locationHeaders.lat) || defaultLocation.lat
-    const lng = qLng || c.req.header(locationHeaders.lng) || defaultLocation.lng
+    const cf = c.req.raw.cf
+    const lat = qLat || c.req.header(locationHeaders.lat) || cf?.latitude || defaultLocation.lat
+    const lng = qLng || c.req.header(locationHeaders.lng) || cf?.longitude || defaultLocation.lng
     const coordinates = trimCoordinates({ lat, lng })
 
     const url = new URL(c.req.url)

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -58,6 +58,43 @@ describe('Routing', () => {
     expect(location.match(/\?/g)).toHaveLength(1)
   })
 
+  // The Workers runtime attaches IP geolocation to request.cf; emulate it here.
+  const withCf = (url, cf, headers) => {
+    const req = new Request(url, headers ? { headers } : undefined)
+    Object.defineProperty(req, 'cf', { value: cf, enumerable: true })
+    return req
+  }
+
+  it('falls back to Cloudflare GeoIP when no query params or Screenly headers', async () => {
+    const res = await app.request(withCf('http://localhost/', { latitude: '40.7128', longitude: '-74.0060' }))
+    expect(res.status).toBe(301)
+    const location = res.headers.get('Location')
+    // Trimmed to 2 decimals; this is New York, not the SF default.
+    expect(location).toContain('lat=40.71')
+    expect(location).toContain('lng=-74.01')
+  })
+
+  it('prefers Screenly location headers over GeoIP', async () => {
+    const res = await app.request(withCf(
+      'http://localhost/',
+      { latitude: '40.7128', longitude: '-74.0060' },
+      { 'x-screenly-lat': '35.68', 'x-screenly-lng': '139.69' }
+    ))
+    expect(res.status).toBe(301)
+    const location = res.headers.get('Location')
+    // Tokyo from the device headers wins over the New York IP.
+    expect(location).toContain('lat=35.68')
+    expect(location).toContain('lng=139.69')
+  })
+
+  it('falls back to the default location when GeoIP is unavailable', async () => {
+    const res = await app.request('http://localhost/')
+    expect(res.status).toBe(301)
+    const location = res.headers.get('Location')
+    expect(location).toContain('lat=37.77')
+    expect(location).toContain('lng=-122.43')
+  })
+
   it('renders the page HTML via hono JSX (server-side)', () => {
     // Mirrors the route's `new Response((<App/>).toString())`.
     const body = jsx(App, { env: 'production', lat: '51.5', lng: '-0.12', v: 'testver' }).toString()


### PR DESCRIPTION
## Why

Requests with no `?lat/&lng` and no Screenly asset-metadata headers (i.e. any normal browser) fell straight through to the hard-coded San Francisco default — so everyone not on a configured Screenly player saw SF weather.

## What

The Workers runtime already attaches IP geolocation to `request.cf` for free. This inserts it into the resolution order, ahead of the default:

```
query params  >  Screenly headers  >  Cloudflare GeoIP (request.cf)  >  SF default
```

```js
const cf = c.req.raw.cf
const lat = qLat || c.req.header(locationHeaders.lat) || cf?.latitude || defaultLocation.lat
const lng = qLng || c.req.header(locationHeaders.lng) || cf?.longitude || defaultLocation.lng
```

- Screenly players keep their precise metadata location (headers still win over GeoIP).
- Everyone else gets their approximate, city-level IP location instead of SF.
- Coordinates still go through `trimCoordinates` (2 decimals), so resolved locations round to ~1km and share page-cache keys exactly as before — no cache-key explosion.

## Caveats

- `request.cf` geo is populated in production at the edge. Under `wrangler dev` it's only present with `--remote`; otherwise it falls back to the SF default (so local dev will still show SF).
- IP geolocation is city-level accurate — fine for weather, not pinpoint.

## Tests

Added cases covering: GeoIP fallback when nothing else is present, headers winning over GeoIP, and the SF default when `cf` is absent. 26 tests pass, `biome lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)