### PR TITLE
Track resolved location in Google Analytics

### DIFF
--- a/assets/static/js/main.js
+++ b/assets/static/js/main.js
@@ -287,6 +287,12 @@ import {
     updateLocation(name)
     initDateTime(timezone)
     updateWeather(list)
+    // Report the resolved location so we can track which places are popular.
+    generateAnalyticsEvent('location', {
+      app_name: 'Screenly Weather App',
+      city: name,
+      country
+    })
   }
 
   /**


### PR DESCRIPTION
## What

Emit a `location` Google Analytics event with the resolved **city** and **country** each time fresh weather data arrives (in `updateData()`), so we can track which places are popular.

```js
generateAnalyticsEvent('location', {
  app_name: 'Screenly Weather App',
  city: name,
  country
})
```

## Why

The app already sent raw `lat`/`lng` on the `cache_status` event, but coordinates are awkward for a "what's popular" breakdown. The weather API response resolves a human-readable `city.name` and `country`, so we report those instead.

## Follow-up needed in GA4 (not code)

For `city` / `country` to be queryable in reports, they must be registered as **event-scoped custom dimensions** in GA4 (Admin → Custom definitions → Custom dimensions), with the Event parameter matching `city` / `country` exactly. This has to be done in **both** GA4 properties, since `src/constants.js` uses separate measurement IDs for stage (`G-JKR8780BXH`) and production (`G-SF5E8GXW6E`). Custom dimensions are not retroactive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)