### PR TITLE
Remove abandoned-project warning from README

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project status
 
-This is a **legacy/abandoned** Screenly Weather App (superseded by the Weather Edge App). It is a Cloudflare Worker that server-renders a full-screen weather display for Screenly digital signage. Live at `weather.srly.io`.
+This is the Screenly Weather App. It is a Cloudflare Worker that server-renders a full-screen weather display for Screenly digital signage. Live at `weather.srly.io`.
 
 The app doubles as a Screenly advertisement: viewers are non-Screenly users, so the UI carries a rotating CTA pitching Screenly. See the auto-memory note `app-is-screenly-advertisement.md` for the CTA/accuracy guardrails.
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # Screenly Weather App
 
-**Warning:** This project has been abandoned in favor of the [Weather Edge App](https://github.com/Screenly/Playground/tree/master/edge-apps/weather).
-
 ![Weather App Screenshot](docs/screenshot.jpg)
 
 This is an example asset for Screenly as part of the [Screenly Playground](https://github.com/Screenly/playground).


### PR DESCRIPTION
Removes the "This project has been abandoned in favor of the Weather Edge App" warning line from the top of the README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)