### PR TITLE
Add degraded mode for older/weaker browsers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ package-lock.json
 
 # Output of 'npm pack'
 *.tgz
+# Claude Code local worktrees/artifacts
+.claude/

--- a/assets/static/js/main.js
+++ b/assets/static/js/main.js
@@ -14,7 +14,7 @@ import {
   getCondCategory
 } from './locale.js'
 
-// This file is bundled by Bun.build and served as a PLAIN classic <script>.
+// This file is bundled by esbuild and served as a PLAIN classic <script>.
 // It must therefore stay a self-executing IIFE with NO top-level `export`:
 // the testable helpers live in ./locale.js (bundled in here), and this file
 // exports nothing. That keeps the served bundle loadable by every cached HTML

--- a/assets/static/js/main.js
+++ b/assets/static/js/main.js
@@ -1,3 +1,6 @@
+// Side-effect import: installs the replaceChildren shim for the older-browser
+// degraded mode. Must stay first so the shim is in place before any render.
+import './polyfills.js'
 import {
   usesFahrenheit,
   unitsCountry,

--- a/assets/static/js/polyfills.js
+++ b/assets/static/js/polyfills.js
@@ -1,0 +1,16 @@
+// Minimal runtime shims for the older-browser degraded mode (target floor ~2018:
+// Chrome 65 / Safari 11.1). esbuild lowers modern *syntax* (?., ??, spread) at
+// build time, but it does not add missing runtime APIs. At this floor the only
+// gap the apps hit is Element.prototype.replaceChildren (Chrome 86 / Safari 14,
+// 2020). Everything else the app needs (Intl, URLSearchParams) already exists at
+// the floor, so this stays a few lines rather than pulling in core-js.
+//
+// Imported for side effects as the first line of main.js. Keep export-free so it
+// never turns the bundle into an ES module.
+
+if (typeof Element !== 'undefined' && !Element.prototype.replaceChildren) {
+  Element.prototype.replaceChildren = function replaceChildren(...nodes) {
+    while (this.firstChild) this.removeChild(this.firstChild)
+    this.append(...nodes)
+  }
+}

--- a/assets/static/js/polyfills.js
+++ b/assets/static/js/polyfills.js
@@ -1,16 +1,20 @@
-// Minimal runtime shims for the older-browser degraded mode (target floor ~2018:
-// Chrome 65 / Safari 11.1). esbuild lowers modern *syntax* (?., ??, spread) at
-// build time, but it does not add missing runtime APIs. At this floor the only
-// gap the apps hit is Element.prototype.replaceChildren (Chrome 86 / Safari 14,
-// 2020). Everything else the app needs (Intl, URLSearchParams) already exists at
-// the floor, so this stays a few lines rather than pulling in core-js.
+// Minimal runtime shim for the older-browser degraded mode. esbuild lowers modern
+// *syntax* (?., ??, spread) at build time, but it does not add missing runtime
+// APIs. The one DOM gap the apps can hit at the support floor is
+// Element.prototype.replaceChildren (Chrome 86 / Safari 14, 2020); it's included
+// as a defensive shim even in apps that don't call it directly. Everything else
+// the apps use (Intl, URLSearchParams) predates the floor, so no core-js.
 //
-// Imported for side effects as the first line of main.js. Keep export-free so it
-// never turns the bundle into an ES module.
+// Imported only for its side effect (installing the shim) as the first line of
+// main.js; it exports nothing.
 
 if (typeof Element !== 'undefined' && !Element.prototype.replaceChildren) {
   Element.prototype.replaceChildren = function replaceChildren(...nodes) {
+    // Build the new children in a fragment first so a bad node throws before we
+    // touch the element, keeping the swap effectively atomic like the native API.
+    const frag = document.createDocumentFragment()
+    frag.append(...nodes)
     while (this.firstChild) this.removeChild(this.firstChild)
-    this.append(...nodes)
+    this.appendChild(frag)
   }
 }

--- a/assets/static/styles/main.css
+++ b/assets/static/styles/main.css
@@ -690,3 +690,27 @@ body[data-cond="thunderstorm"] .weather-fx {
     display: none;
   }
 }
+
+/* =========================================================================
+   Degraded mode — old/weak signage players (html.legacy set by the inline gate
+   in Layout.jsx). Assume the device can't afford animation; drop it entirely.
+   Mirrors the reduced-motion resting state: .anim has a base opacity:0 and only
+   appears via the entrance animation (which the kill-switch removes), so reveal
+   it; and drop the decorative weather FX layer rather than freezing it.
+   ========================================================================= */
+html.legacy .anim {
+  opacity: 1;
+}
+html.legacy .weather-fx {
+  display: none;
+}
+html.legacy *,
+html.legacy *::before,
+html.legacy *::after {
+  /* biome-ignore lint/complexity/noImportantStyles: kill-switch must override the entrance/FX animation rules */
+  animation: none !important;
+  /* biome-ignore lint/complexity/noImportantStyles: kill-switch must override any transition */
+  transition: none !important;
+  /* biome-ignore lint/complexity/noImportantStyles: release GPU layer hints on weak devices */
+  will-change: auto !important;
+}

--- a/build.js
+++ b/build.js
@@ -5,53 +5,56 @@
 // referenced at /static/..., so the minified output must overwrite the source.
 
 import { Glob } from 'bun'
+import browserslist from 'browserslist'
+import { build as esbuild } from 'esbuild'
+import { browserslistToTargets, transform as lightningcss } from 'lightningcss'
 import { run as syncFonts } from './sync-fonts.js'
+
+// Single browser-support floor for the whole build: the `browserslist` field in
+// package.json drives both the CSS down-leveling (Lightning CSS) and the JS
+// syntax floor, so old signage players get a build they can actually run. See
+// the degraded-mode notes in Layout.jsx / main.css.
+const cssTargets = browserslistToTargets(browserslist())
 
 // Vendor the Bun-managed webfonts into ./assets before minifying.
 await syncFonts()
 
-// main.js is the only JS *entry*. It imports ./locale.js (the unit-tested pure
-// helpers), and `external: []` tells Bun to inline that import. main.js itself
-// exports nothing, so the bundle is a self-executing classic script with no
-// `export` token — loadable by every cached HTML variant (plain <script> or
-// type="module") so a deploy never strands cached pages. locale.js is a
-// dependency, not an entry, so it is never built/served on its own.
-const cssEntries = []
+// main.js is the only JS *entry*. It imports ./locale.js (and the polyfills shim);
+// esbuild inlines those and lowers modern syntax (?., ??, spread) to the ES2017
+// floor so old engines can parse it. format:'iife' keeps the output a self-
+// executing classic script with no `export`/`import` token — loadable by every
+// cached HTML variant so a deploy never strands cached pages. allowOverwrite lets
+// esbuild write back over the entry (assets are served in place by wrangler).
+try {
+  await esbuild({
+    entryPoints: ['assets/static/js/main.js'],
+    bundle: true,
+    minify: true,
+    format: 'iife',
+    target: ['es2017'],
+    outfile: 'assets/static/js/main.js',
+    allowOverwrite: true
+  })
+} catch (error) {
+  console.error('✗ Failed to build assets/static/js/main.js')
+  console.error(error)
+  process.exit(1)
+}
+console.log('✓ JS: assets/static/js/main.js (esbuild, iife, es2017)')
+
+// CSS: Lightning CSS down-levels each stylesheet to the browserslist floor and
+// minifies in place. url(/static/...) refs are left untouched.
+let count = 1
 for await (const path of new Glob('assets/static/styles/*.css').scan('.')) {
-  cssEntries.push(path)
+  const { code } = lightningcss({
+    filename: path,
+    code: await Bun.file(path).bytes(),
+    minify: true,
+    targets: cssTargets
+  })
+  await Bun.write(path, code)
+  console.log(`✓ CSS: ${path}`)
+  count++
 }
 
-const targets = [
-  // Bundle local imports (external: []).
-  { label: 'JS', entries: ['assets/static/js/main.js'], external: [] },
-  // Leave url(/static/...) refs untouched rather than resolving them as
-  // build-time assets (external: ['*']).
-  { label: 'CSS', entries: cssEntries, external: ['*'] }
-]
-
-let count = 0
-
-for (const { label, entries, external } of targets) {
-  for (const path of entries) {
-    const result = await Bun.build({
-      entrypoints: [path],
-      minify: true,
-      target: 'browser',
-      external
-    })
-
-    if (!result.success) {
-      console.error(`✗ Failed to build ${path}`)
-      for (const message of result.logs) console.error(message)
-      process.exit(1)
-    }
-
-    // Build fully into memory before writing, so overwriting the source is safe.
-    const minified = await result.outputs[0].text()
-    await Bun.write(path, minified)
-    console.log(`✓ ${label}: ${path}`)
-    count++
-  }
-}
-
-console.log(`Build complete — ${count} file(s) minified in place.`)
+console.log(`Build complete — ${count} file(s) built in place.`)

--- a/build.js
+++ b/build.js
@@ -10,9 +10,10 @@ import { build as esbuild } from 'esbuild'
 import { browserslistToTargets, transform as lightningcss } from 'lightningcss'
 import { run as syncFonts } from './sync-fonts.js'
 
-// Single browser-support floor for the whole build: the `browserslist` field in
-// package.json drives both the CSS down-leveling (Lightning CSS) and the JS
-// syntax floor, so old signage players get a build they can actually run. See
+// The `browserslist` field in package.json is the CSS support floor: Lightning
+// CSS down-levels the stylesheet to it. The JS is lowered separately by esbuild to
+// a fixed ES2017 syntax floor (kept at/below the browserslist minimum); esbuild
+// can't read browserslist, so keep the two in sync if you change the floor. See
 // the degraded-mode notes in Layout.jsx / main.css.
 const cssTargets = browserslistToTargets(browserslist())
 
@@ -46,13 +47,19 @@ console.log('✓ JS: assets/static/js/main.js (esbuild, iife, es2017)')
 // minifies in place. url(/static/...) refs are left untouched.
 let count = 1
 for await (const path of new Glob('assets/static/styles/*.css').scan('.')) {
-  const { code } = lightningcss({
-    filename: path,
-    code: await Bun.file(path).bytes(),
-    minify: true,
-    targets: cssTargets
-  })
-  await Bun.write(path, code)
+  try {
+    const { code } = lightningcss({
+      filename: path,
+      code: await Bun.file(path).bytes(),
+      minify: true,
+      targets: cssTargets
+    })
+    await Bun.write(path, code)
+  } catch (error) {
+    console.error(`✗ Failed to build ${path}`)
+    console.error(error)
+    process.exit(1)
+  }
   console.log(`✓ CSS: ${path}`)
   count++
 }

--- a/bun.lock
+++ b/bun.lock
@@ -12,6 +12,9 @@
       "devDependencies": {
         "@biomejs/biome": "^2.5.1",
         "@cloudflare/workers-types": "^4.20260623.1",
+        "browserslist": "^4.28.6",
+        "esbuild": "^0.28.1",
+        "lightningcss": "^1.32.0",
         "wrangler": "^4.104.0",
       },
     },
@@ -177,15 +180,25 @@
 
     "@speed-highlight/core": ["@speed-highlight/core@1.2.17", "", {}, "sha512-Z92FwKpCtfaW1V0jTU/fh3QzYEZN8wDwrzRIBoADCJfn4mJCNcJN/XegifX7BDrQ8/h9Xh/JnbyMchL0FqXrkg=="],
 
+    "baseline-browser-mapping": ["baseline-browser-mapping@2.10.43", "", { "bin": { "baseline-browser-mapping": "dist/cli.cjs" } }, "sha512-AjYpR78kDWAY3Efj+cDTFH9t9SCoL7OoTp1BOb0mQV7S+6CiLwnWM3FyxhJtdPufDFKzmCSFoUncKjWgJEZTCQ=="],
+
     "blake3-wasm": ["blake3-wasm@2.1.5", "", {}, "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g=="],
+
+    "browserslist": ["browserslist@4.28.6", "", { "dependencies": { "baseline-browser-mapping": "^2.10.42", "caniuse-lite": "^1.0.30001803", "electron-to-chromium": "^1.5.389", "node-releases": "^2.0.51", "update-browserslist-db": "^1.2.3" }, "bin": { "browserslist": "cli.js" } }, "sha512-FQBYNK15VMslhLHpA7+n+n1GOlF1kId2xcCg7/j95f24AOF6VDYMNH4mFxF7KuaTdv627faazpOAjFzMrfJOUw=="],
+
+    "caniuse-lite": ["caniuse-lite@1.0.30001805", "", {}, "sha512-52noaS3DubycKSXaU30TwPGIp+POyQSUVa5jBEq3vkRkY0kjyb3LQgvhU6WGyCcyXqVLWO0Cw0Q6BSdD0kUfVA=="],
 
     "cookie": ["cookie@1.1.1", "", {}, "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="],
 
     "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
 
+    "electron-to-chromium": ["electron-to-chromium@1.5.389", "", {}, "sha512-cEto7aeOqBfU1D+c5py5pE+ooscKE75JifxLBdFUZsqAxRS6y7kebtxAZvICszSl05gPjYHDTjY+lXpyGvpJbg=="],
+
     "error-stack-parser-es": ["error-stack-parser-es@1.0.5", "", {}, "sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA=="],
 
     "esbuild": ["esbuild@0.28.1", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.28.1", "@esbuild/android-arm": "0.28.1", "@esbuild/android-arm64": "0.28.1", "@esbuild/android-x64": "0.28.1", "@esbuild/darwin-arm64": "0.28.1", "@esbuild/darwin-x64": "0.28.1", "@esbuild/freebsd-arm64": "0.28.1", "@esbuild/freebsd-x64": "0.28.1", "@esbuild/linux-arm": "0.28.1", "@esbuild/linux-arm64": "0.28.1", "@esbuild/linux-ia32": "0.28.1", "@esbuild/linux-loong64": "0.28.1", "@esbuild/linux-mips64el": "0.28.1", "@esbuild/linux-ppc64": "0.28.1", "@esbuild/linux-riscv64": "0.28.1", "@esbuild/linux-s390x": "0.28.1", "@esbuild/linux-x64": "0.28.1", "@esbuild/netbsd-arm64": "0.28.1", "@esbuild/netbsd-x64": "0.28.1", "@esbuild/openbsd-arm64": "0.28.1", "@esbuild/openbsd-x64": "0.28.1", "@esbuild/openharmony-arm64": "0.28.1", "@esbuild/sunos-x64": "0.28.1", "@esbuild/win32-arm64": "0.28.1", "@esbuild/win32-ia32": "0.28.1", "@esbuild/win32-x64": "0.28.1" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw=="],
+
+    "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
 
     "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
@@ -193,11 +206,39 @@
 
     "kleur": ["kleur@4.1.5", "", {}, "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ=="],
 
+    "lightningcss": ["lightningcss@1.32.0", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-android-arm64": "1.32.0", "lightningcss-darwin-arm64": "1.32.0", "lightningcss-darwin-x64": "1.32.0", "lightningcss-freebsd-x64": "1.32.0", "lightningcss-linux-arm-gnueabihf": "1.32.0", "lightningcss-linux-arm64-gnu": "1.32.0", "lightningcss-linux-arm64-musl": "1.32.0", "lightningcss-linux-x64-gnu": "1.32.0", "lightningcss-linux-x64-musl": "1.32.0", "lightningcss-win32-arm64-msvc": "1.32.0", "lightningcss-win32-x64-msvc": "1.32.0" } }, "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ=="],
+
+    "lightningcss-android-arm64": ["lightningcss-android-arm64@1.32.0", "", { "os": "android", "cpu": "arm64" }, "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg=="],
+
+    "lightningcss-darwin-arm64": ["lightningcss-darwin-arm64@1.32.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ=="],
+
+    "lightningcss-darwin-x64": ["lightningcss-darwin-x64@1.32.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w=="],
+
+    "lightningcss-freebsd-x64": ["lightningcss-freebsd-x64@1.32.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig=="],
+
+    "lightningcss-linux-arm-gnueabihf": ["lightningcss-linux-arm-gnueabihf@1.32.0", "", { "os": "linux", "cpu": "arm" }, "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw=="],
+
+    "lightningcss-linux-arm64-gnu": ["lightningcss-linux-arm64-gnu@1.32.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ=="],
+
+    "lightningcss-linux-arm64-musl": ["lightningcss-linux-arm64-musl@1.32.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg=="],
+
+    "lightningcss-linux-x64-gnu": ["lightningcss-linux-x64-gnu@1.32.0", "", { "os": "linux", "cpu": "x64" }, "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA=="],
+
+    "lightningcss-linux-x64-musl": ["lightningcss-linux-x64-musl@1.32.0", "", { "os": "linux", "cpu": "x64" }, "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg=="],
+
+    "lightningcss-win32-arm64-msvc": ["lightningcss-win32-arm64-msvc@1.32.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw=="],
+
+    "lightningcss-win32-x64-msvc": ["lightningcss-win32-x64-msvc@1.32.0", "", { "os": "win32", "cpu": "x64" }, "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q=="],
+
     "miniflare": ["miniflare@4.20260623.0", "", { "dependencies": { "@cspotcode/source-map-support": "0.8.1", "sharp": "0.34.5", "undici": "7.28.0", "workerd": "1.20260623.1", "ws": "8.21.0", "youch": "4.1.0-beta.10" }, "bin": { "miniflare": "bootstrap.js" } }, "sha512-p2YTeH01jMiMOjO4v9hb/+GJndja5LCxecGOWCaT9F414PRXgdddLDsK6MnqhGBB5tlU/WoBYIG1XZte5pQzOQ=="],
+
+    "node-releases": ["node-releases@2.0.51", "", {}, "sha512-wRNIrw4DmVLKQlbgOMdkMx27Wrpzes2hh5Jtbi2bjPd+4wJstWIqP5A+lscnqbm0xxmT5Bpg8Lec5ItEBwx6BQ=="],
 
     "path-to-regexp": ["path-to-regexp@6.3.0", "", {}, "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ=="],
 
     "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
+
+    "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
     "semver": ["semver@7.8.5", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA=="],
 
@@ -210,6 +251,8 @@
     "undici": ["undici@7.28.0", "", {}, "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA=="],
 
     "unenv": ["unenv@2.0.0-rc.24", "", { "dependencies": { "pathe": "^2.0.3" } }, "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw=="],
+
+    "update-browserslist-db": ["update-browserslist-db@1.2.3", "", { "dependencies": { "escalade": "^3.2.0", "picocolors": "^1.1.1" }, "peerDependencies": { "browserslist": ">= 4.21.0" }, "bin": { "update-browserslist-db": "cli.js" } }, "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w=="],
 
     "workerd": ["workerd@1.20260623.1", "", { "optionalDependencies": { "@cloudflare/workerd-darwin-64": "1.20260623.1", "@cloudflare/workerd-darwin-arm64": "1.20260623.1", "@cloudflare/workerd-linux-64": "1.20260623.1", "@cloudflare/workerd-linux-arm64": "1.20260623.1", "@cloudflare/workerd-windows-64": "1.20260623.1" }, "bin": { "workerd": "bin/workerd" } }, "sha512-9SJsdTSsehhqc26TUJIzyi1XgyYeqFym4hinZnWoAP1BkhEoMQ5Ygz7Xw9T+2ecU+y409JBEScBgWTdZ06mBrg=="],
 

--- a/package.json
+++ b/package.json
@@ -15,6 +15,12 @@
     "deploy": "wrangler deploy --env=dev"
   },
   "license": "AGPL-3.0-only",
+  "browserslist": [
+    "chrome >= 65",
+    "safari >= 11.1",
+    "edge >= 79",
+    "firefox >= 60"
+  ],
   "dependencies": {
     "@fontsource-variable/fraunces": "^5.2.9",
     "@fontsource-variable/hanken-grotesk": "^5.2.8",
@@ -23,6 +29,9 @@
   "devDependencies": {
     "@biomejs/biome": "^2.5.1",
     "@cloudflare/workers-types": "^4.20260623.1",
+    "browserslist": "^4.28.6",
+    "esbuild": "^0.28.1",
+    "lightningcss": "^1.32.0",
     "wrangler": "^4.104.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -16,10 +16,10 @@
   },
   "license": "AGPL-3.0-only",
   "browserslist": [
-    "chrome >= 65",
+    "chrome >= 79",
+    "firefox >= 75",
     "safari >= 11.1",
-    "edge >= 79",
-    "firefox >= 60"
+    "edge >= 79"
   ],
   "dependencies": {
     "@fontsource-variable/fraunces": "^5.2.9",

--- a/src/components/Layout.jsx
+++ b/src/components/Layout.jsx
@@ -21,20 +21,19 @@ const Layout = (props) => html`<!DOCTYPE html>
       />
       <!-- Degraded mode for older/weaker signage players. Runs before the
            stylesheet so html.legacy is set on the first paint: flags the device
-           as legacy when the browser engine is old (missing a 2020-era feature)
-           or the hardware looks weak, then the stylesheet drops all animation. -->
+           as legacy when the browser engine is old (no Element.replaceChildren,
+           a 2020-era API) or the hardware looks weak, then the stylesheet drops
+           all animation. classList.add keeps it idempotent. -->
       <script>
         (function () {
           try {
             var slow =
               (navigator.deviceMemory && navigator.deviceMemory <= 2) ||
               (navigator.hardwareConcurrency && navigator.hardwareConcurrency <= 2)
-            var old =
-              !('replaceChildren' in Element.prototype) ||
-              !(window.CSS && CSS.supports && CSS.supports('color', 'color-mix(in oklab, red, blue)'))
-            if (slow || old) document.documentElement.className += ' legacy'
+            var old = !('replaceChildren' in Element.prototype)
+            if (slow || old) document.documentElement.classList.add('legacy')
           } catch (e) {
-            document.documentElement.className += ' legacy'
+            document.documentElement.classList.add('legacy')
           }
         })()
       </script>

--- a/src/components/Layout.jsx
+++ b/src/components/Layout.jsx
@@ -19,6 +19,25 @@ const Layout = (props) => html`<!DOCTYPE html>
         type="font/woff2"
         crossorigin
       />
+      <!-- Degraded mode for older/weaker signage players. Runs before the
+           stylesheet so html.legacy is set on the first paint: flags the device
+           as legacy when the browser engine is old (missing a 2020-era feature)
+           or the hardware looks weak, then the stylesheet drops all animation. -->
+      <script>
+        (function () {
+          try {
+            var slow =
+              (navigator.deviceMemory && navigator.deviceMemory <= 2) ||
+              (navigator.hardwareConcurrency && navigator.hardwareConcurrency <= 2)
+            var old =
+              !('replaceChildren' in Element.prototype) ||
+              !(window.CSS && CSS.supports && CSS.supports('color', 'color-mix(in oklab, red, blue)'))
+            if (slow || old) document.documentElement.className += ' legacy'
+          } catch (e) {
+            document.documentElement.className += ' legacy'
+          }
+        })()
+      </script>
       <link rel="stylesheet" href="/static/styles/main.css?v=${props.v}" />
       <!-- Expose the asset version so main.js can cache-bust the image URLs it
            builds at runtime (weather icons, backgrounds). -->


### PR DESCRIPTION
## What & why
Cloudflare Worker (JS) sibling to the moon pilot ([Screenly-Labs/moon#4](https://github.com/Screenly-Labs/moon/pull/4)). On the support floor (Chrome 79 / Safari 11.1) a single `?.`/`??` token kills the client bundle. Makes the full app run on the floor and drop animation on weak hardware.

## Build (one `browserslist` floor)
- **JS → esbuild** (`iife`, `es2017`, `allowOverwrite` since `main.js` is bundled in place) replacing `Bun.build`; plain-JS `replaceChildren` shim.
- **CSS → Lightning CSS** down-level + minify in place.

## Degraded gate
Inline `<head>` script in `Layout.jsx` sets `html.legacy`; CSS kill-switch drops animation/transition. **`.anim` has a base `opacity:0`** and only appears via the entrance animation, so the legacy block reveals it (`opacity:1`) and drops the decorative `.weather-fx` particle layer — mirroring the existing `prefers-reduced-motion` resting state.

## Verification (both modes)
`lint`, **44 tests**, `es-check es2017` pass. `wrangler dev` screenshots: shell fully styled (dark theme + brand glyph), gate flips, CTA/`.anim` content visible under `html.legacy`. (Live weather region needs the OpenWeather key, absent in local dev — unrelated to this change.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
**Support floor updated:** raised to **Chrome 79 / Firefox 75 / Safari 11.1 / Edge 79** (from the initial ~2018/Chrome 65 target). The apps use `clamp()`/`min()`/`max()` pervasively, which require Chrome 79 (Safari 11.1); Lightning CSS cannot polyfill them, so Chrome 79 is the honest floor where the CSS renders. Still catches the vast majority of old signage players; WebKit stays at 2018 (Safari 11.1).