### PR TITLE
Promote to production: Chrome 87 CSS floor fix (logical properties)

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,10 +16,10 @@
   },
   "license": "AGPL-3.0-only",
   "browserslist": [
-    "chrome >= 79",
-    "firefox >= 75",
-    "safari >= 11.1",
-    "edge >= 79"
+    "chrome >= 87",
+    "firefox >= 78",
+    "safari >= 14.1",
+    "edge >= 87"
   ],
   "dependencies": {
     "@fontsource-variable/fraunces": "^5.2.9",


### PR DESCRIPTION
Promotes the logical-properties floor fix (Chrome 87 / Safari 14.1) to production. Fixes dropped logical-property positioning (e.g. the QR) on browsers below Chrome 87.

🤖 Generated with [Claude Code](https://claude.com/claude-code)