### PR TITLE
Promote to production: signage-kit 2026.7.2 chrome + standardized badge

### DIFF
--- a/assets/static/js/main.src.js
+++ b/assets/static/js/main.src.js
@@ -2,6 +2,7 @@
 // degraded mode (shared via @screenly-labs/signage-kit). Must stay first so the
 // shim is in place before any render.
 import '@screenly-labs/signage-kit/polyfills'
+import { removeScreenlyBranding } from '@screenly-labs/signage-kit/branding'
 import {
   usesFahrenheit,
   unitsCountry,
@@ -25,7 +26,6 @@ import {
   let clockTimer
   let weatherTimer
   let refreshTimer
-  let ctaTimer
   let tz
   let currentWeatherId
   let tempScale = 'C'
@@ -41,13 +41,6 @@ import {
   const withVersion = (url) => (assetVersion ? `${url}?v=${assetVersion}` : url)
 
   const getTemp = (temp) => Math.round(tempScale === 'C' ? temp : celsiusToFahrenheit(temp))
-
-  /**
-   * Utility Functions
-   */
-  const generateAnalyticsEvent = (name, payload) => {
-    typeof gtag !== 'undefined' && gtag('event', name, payload) // eslint-disable-line no-undef
-  }
 
   const checkIfNight = (dt) => {
     const dateTime = getTimeByOffset(tz, dt)
@@ -295,12 +288,6 @@ import {
     updateLocation(name)
     initDateTime(timezone)
     updateWeather(list)
-    // Report the resolved location so we can track which places are popular.
-    generateAnalyticsEvent('location', {
-      app_name: 'Screenly Weather App',
-      city: name,
-      country
-    })
   }
 
   /**
@@ -312,74 +299,13 @@ import {
     try {
       const { lat, lng } = getLocation()
       const response = await fetch(`/api/weather?lat=${lat}&lng=${lng}`)
-      const isCacheHit = response.headers.get('cf-cache-status') === 'HIT'
       const data = await response.json()
       updateData(data)
-      generateAnalyticsEvent('cache_status', {
-        app_name: 'Screenly Weather App',
-        cached: isCacheHit,
-        lat,
-        lng
-      })
     } catch (e) {
       console.log(e)
     }
     // Reschedule the next refresh so updates keep coming every 2 hours.
     refreshTimer = setTimeout(fetchWeather, 120 * 60 * 1000)
-  }
-
-  /**
-   * Rotating Screenly call-to-action.
-   *
-   * The banner is only shown on non-Screenly devices (a browser tab or a rival
-   * signage system), so the copy pitches the viewer to switch to Screenly. It
-   * is non-interactive (a digital sign has no cursor/touch) and surfaces
-   * screenly.io as the destination a viewer types in themselves.
-   */
-  const ctaMessages = [
-    'Powerful, secure, simple digital signage',
-    'Secure by default: SOC 2, zero-trust',
-    'Manage every screen from anywhere',
-    'Run Screenly on hardware you already own',
-    'Powering 10,000+ screens worldwide'
-  ]
-  let ctaIndex = 0
-
-  const rotateCta = () => {
-    const msg = document.querySelector('#cta-msg')
-    if (!msg) return
-
-    ctaIndex = (ctaIndex + 1) % ctaMessages.length
-    const next = ctaMessages[ctaIndex]
-    const reduceMotion = window.matchMedia?.('(prefers-reduced-motion: reduce)')?.matches ?? false
-
-    if (reduceMotion) {
-      msg.textContent = next
-      return
-    }
-
-    msg.classList.add('is-out')
-    setTimeout(() => {
-      msg.textContent = next
-      msg.classList.remove('is-out')
-    }, 450)
-  }
-
-  const setBanner = () => {
-    const banner = document.querySelector('.upgrade-banner')
-    const { userAgent } = navigator
-    const isScreenlyDevice = userAgent.includes('screenly-viewer')
-
-    if (banner && !isScreenlyDevice) {
-      banner.classList.add('visible')
-      clearInterval(ctaTimer)
-      ctaTimer = setInterval(rotateCta, 5000)
-    }
-
-    generateAnalyticsEvent('device', {
-      app_name: 'Screenly Weather App',
-      screenly_device: isScreenlyDevice
-    })
   }
 
   const init = () => {
@@ -393,7 +319,7 @@ import {
     setTimeFormat(params.get('24h'))
     // fetchWeather() reschedules itself every 2 hours.
     fetchWeather()
-    setBanner()
+    removeScreenlyBranding()
   }
 
   // Only auto-run in a real browser; under a test runner there is no document.

--- a/assets/static/styles/main.css
+++ b/assets/static/styles/main.css
@@ -6,29 +6,9 @@
    only layers legibility + the reactive accent on top.
    ========================================================================= */
 
-/* ---- Webfonts: self-hosted, vendored from Bun-managed @fontsource --------
-   (see sync-fonts.js). Variable "standard" axis = optical-size + weight. */
-@font-face {
-  font-family: "Fraunces";
-  font-style: normal;
-  font-weight: 100 900;
-  font-display: swap;
-  src: url("/static/fonts/fraunces-latin-standard-normal.woff2") format("woff2");
-}
-@font-face {
-  font-family: "Fraunces";
-  font-style: italic;
-  font-weight: 100 900;
-  font-display: swap;
-  src: url("/static/fonts/fraunces-latin-standard-italic.woff2") format("woff2");
-}
-@font-face {
-  font-family: "Hanken Grotesk";
-  font-style: normal;
-  font-weight: 100 900;
-  font-display: swap;
-  src: url("/static/fonts/hanken-grotesk-latin-wght-normal.woff2") format("woff2");
-}
+/* Webfonts (@font-face) and the standardized footer badge (.brand) come from
+   @screenly-labs/signage-kit — build.js prepends styles/fonts.css + styles/brand.css
+   before down-leveling. This file keeps the app's own tokens, reset, and styles. */
 
 /* Registered so the weather-reactive accent can interpolate on change. */
 @property --accent {
@@ -103,7 +83,7 @@ body[data-cond="haze"]         { --accent: #e0c79a; }
 body[data-night="true"]        { --accent: #b6a6f2; }
 
 /* =========================================================================
-   Layout shell — grid: masthead / hero+CTA / forecast rail
+   Layout shell — grid: masthead / hero / forecast rail
    ========================================================================= */
 .content {
   position: relative;
@@ -190,7 +170,7 @@ body[data-night="true"]        { --accent: #b6a6f2; }
 }
 
 /* =========================================================================
-   Mid row — hero (current weather) + rotating Screenly CTA
+   Mid row — hero (current weather)
    ========================================================================= */
 .midrow {
   display: flex;
@@ -286,57 +266,6 @@ body[data-night="true"]        { --accent: #b6a6f2; }
   content: "·";
   margin-inline-end: 0.45em;
   opacity: 0.55;
-}
-
-/* ---- Rotating Screenly CTA (shown only on non-Screenly devices) ----------
-   Non-interactive: a digital sign has no cursor/touch, so the screenly.io
-   mark is the destination a viewer reads and types in themselves. */
-.cta-wrap {
-  flex: none;
-  text-align: right;
-}
-
-.upgrade-banner {
-  display: none;
-}
-
-.upgrade-banner.visible {
-  display: inline-flex;
-  flex-direction: column;
-  align-items: flex-end;
-  gap: 0.4rem;
-}
-
-.cta-msg {
-  font-size: 0.84rem;
-  letter-spacing: 0.015em;
-  color: var(--ink-dim);
-  white-space: nowrap;
-  transition: opacity 0.45s ease, transform 0.45s ease;
-}
-
-.cta-msg.is-out {
-  opacity: 0;
-  transform: translateY(-0.25em);
-}
-
-.cta-lockup {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.6em;
-}
-
-.cta-logo {
-  block-size: 1.05rem;
-  inline-size: auto;
-  filter: drop-shadow(0 0.05em 0.4em rgb(0 0 0 / 0.45));
-}
-
-.cta-url {
-  font-size: max(12px, 0.66rem);
-  text-transform: uppercase;
-  letter-spacing: 0.22em;
-  color: var(--ink-dim);
 }
 
 /* =========================================================================
@@ -626,7 +555,7 @@ body[data-cond="thunderstorm"] .weather-fx {
     gap: 0.5rem;
   }
 
-  /* Stack hero + CTA, gravitate to the bottom, both left-aligned. */
+  /* Gravitate the hero to the bottom, left-aligned. */
   .midrow {
     flex-direction: column;
     align-items: flex-start;
@@ -637,15 +566,6 @@ body[data-cond="thunderstorm"] .weather-fx {
   .hero {
     align-self: flex-start;
     max-inline-size: none;
-  }
-
-  .cta-wrap {
-    text-align: left;
-    max-inline-size: none;
-  }
-
-  .upgrade-banner.visible {
-    align-items: flex-start;
   }
 
   #current-temp {
@@ -678,10 +598,6 @@ body[data-cond="thunderstorm"] .weather-fx {
 
   .playing .anim {
     animation: none;
-  }
-
-  .cta-msg {
-    transition: none;
   }
 
   /* Drop the decorative weather FX layer entirely (ambient motion + particles)

--- a/build.js
+++ b/build.js
@@ -15,11 +15,20 @@
 // if the on-disk CSS lacks the html.legacy kill-switch a `bun run dev` build
 // won't add it; build without --client to exercise degraded mode locally.
 
+import { readFileSync } from 'node:fs'
 import { Glob } from 'bun'
 import { bundleJs, processCss } from '@screenly-labs/signage-kit/build'
 import { run as syncFonts } from './sync-fonts.js'
 
 const clientOnly = process.argv.includes('--client')
+
+// Shared chrome CSS from @screenly-labs/signage-kit — the canonical @font-face set
+// and the standardized fixed footer badge. Prepended to this app's raw main.css at
+// build time (a raw-CSS Worker can't resolve a bare `@import`), so the shared rules
+// land before the app's, which override where they overlap.
+const sharedCss = ['fonts.css', 'brand.css']
+  .map((f) => readFileSync(Bun.resolveSync(`@screenly-labs/signage-kit/styles/${f}`, import.meta.dir), 'utf8'))
+  .join('\n')
 
 // Vendor the Bun-managed webfonts into ./assets first.
 await syncFonts()
@@ -41,7 +50,7 @@ console.log('✓ JS: assets/static/js/main.js')
 if (!clientOnly) {
   for await (const path of new Glob('assets/static/styles/*.css').scan('.')) {
     try {
-      const code = await processCss(await Bun.file(path).text(), {
+      const code = await processCss(`${sharedCss}\n${await Bun.file(path).text()}`, {
         includeDegraded: true,
         filename: path
       })

--- a/bun.lock
+++ b/bun.lock
@@ -5,9 +5,7 @@
     "": {
       "name": "screenly-weather-app",
       "dependencies": {
-        "@fontsource-variable/fraunces": "^5.2.9",
-        "@fontsource-variable/hanken-grotesk": "^5.2.8",
-        "@screenly-labs/signage-kit": "github:Screenly-Labs/signage-kit#2026.7.0",
+        "@screenly-labs/signage-kit": "github:Screenly-Labs/signage-kit#2026.7.2",
         "hono": "^4.12.27",
       },
       "devDependencies": {
@@ -111,9 +109,17 @@
 
     "@esbuild/win32-x64": ["@esbuild/win32-x64@0.28.1", "", { "os": "win32", "cpu": "x64" }, "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A=="],
 
+    "@fontsource-variable/bricolage-grotesque": ["@fontsource-variable/bricolage-grotesque@5.2.10", "", {}, "sha512-5EDsCqgGpKVcJWE4sg9ydli+t5WM97mISYw5lla/Ev4z71FwXh1oN0YUU8xjkRW9+wBCGD9R+ntAvI8G4bUFJg=="],
+
     "@fontsource-variable/fraunces": ["@fontsource-variable/fraunces@5.2.9", "", {}, "sha512-Y6IjunlN9Ni723np+GIgAaKzCDBrPRrqNi01TZxHs5wtHYROWFM9W6yiT+/gGwSjWIRD18oX17kD/BRWekc/Lw=="],
 
     "@fontsource-variable/hanken-grotesk": ["@fontsource-variable/hanken-grotesk@5.2.8", "", {}, "sha512-K7hu09ZKReBc7EifRLeM4K94NZBrxFEg0nGcISmVwlFQOJo4EmYkLXTWEwr5JcNW4z2hr5zy8vLS2sxC8JDmrQ=="],
+
+    "@fontsource-variable/jetbrains-mono": ["@fontsource-variable/jetbrains-mono@5.2.8", "", {}, "sha512-WBA9elru6Jdp5df2mES55wuOO0WIrn3kpXnI4+W2ek5u3ZgLS9XS4gmIlcQhiZOWEKl95meYdvK7xI+ETLCq/Q=="],
+
+    "@fontsource-variable/newsreader": ["@fontsource-variable/newsreader@5.2.10", "", {}, "sha512-MdI2iRwrqWpMOU/2aV2BgfZ4dJNlj/XlYaY8Zb7t87mWqHskYW0XiUANkt1cyOCiEfW2VQ0bQ5vZgGPp6B2B4w=="],
+
+    "@fontsource/space-mono": ["@fontsource/space-mono@5.2.9", "", {}, "sha512-b61faFOHEISQ/pD25G+cfGY9o/WW6lRv6hBQQfpWvEJ4y1V+S4gmth95EVyBE2VL3qDYHeVQ8nBzrplzdXTDDg=="],
 
     "@img/colour": ["@img/colour@1.1.0", "", {}, "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ=="],
 
@@ -177,7 +183,7 @@
 
     "@poppinss/exception": ["@poppinss/exception@1.2.3", "", {}, "sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw=="],
 
-    "@screenly-labs/signage-kit": ["@screenly-labs/signage-kit@github:Screenly-Labs/signage-kit#eb470fb", { "peerDependencies": { "@csstools/postcss-cascade-layers": "^6", "browserslist": "^4", "esbuild": "^0.28", "lightningcss": "^1.32", "postcss": "^8" }, "optionalPeers": ["@csstools/postcss-cascade-layers", "postcss"] }, "Screenly-Labs-signage-kit-eb470fb", "sha512-acuAb2R/77crUjgnT9GFVlNdpgUTzvK5OLRRsZsZ30dZcJ7ThH/f8al2janEIJWC1JoyqTiarJ2x1uAH6In86A=="],
+    "@screenly-labs/signage-kit": ["@screenly-labs/signage-kit@github:Screenly-Labs/signage-kit#b7f3d44", { "dependencies": { "@fontsource-variable/bricolage-grotesque": "^5.2.10", "@fontsource-variable/fraunces": "^5.2.9", "@fontsource-variable/hanken-grotesk": "^5.2.8", "@fontsource-variable/jetbrains-mono": "^5.2.8", "@fontsource-variable/newsreader": "^5.2.10", "@fontsource/space-mono": "^5.2.9" }, "peerDependencies": { "@csstools/postcss-cascade-layers": "^6", "browserslist": "^4", "esbuild": "^0.28", "lightningcss": "^1.32", "postcss": "^8" }, "optionalPeers": ["@csstools/postcss-cascade-layers", "postcss"] }, "Screenly-Labs-signage-kit-b7f3d44", "sha512-42YdnSCPpYpTyMucl1T+FGv3HQeyzz2UDEvYoLdP4EMVAD1m0U1G8WN2hgTE4vFVs3w8hGcqFisWBjkEc26rFA=="],
 
     "@sindresorhus/is": ["@sindresorhus/is@7.2.0", "", {}, "sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw=="],
 

--- a/package.json
+++ b/package.json
@@ -16,9 +16,7 @@
   },
   "license": "AGPL-3.0-only",
   "dependencies": {
-    "@fontsource-variable/fraunces": "^5.2.9",
-    "@fontsource-variable/hanken-grotesk": "^5.2.8",
-    "@screenly-labs/signage-kit": "github:Screenly-Labs/signage-kit#2026.7.0",
+    "@screenly-labs/signage-kit": "github:Screenly-Labs/signage-kit#2026.7.2",
     "hono": "^4.12.27"
   },
   "devDependencies": {

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -15,15 +15,15 @@ const Footer = (props) => html`
       <div class="detail anim" id="detail" style="--d: 460ms"></div>
     </section>
 
-    <aside class="cta-wrap anim" style="--d: 520ms">
-      <div class="upgrade-banner">
-        <span class="cta-msg" id="cta-msg">Powerful, secure, simple digital signage</span>
-        <span class="cta-lockup">
-          <img class="cta-logo" src="/static/images/screenly-logo.svg?v=${props.v}" alt="Screenly" width="178" height="40" />
-          <span class="cta-url">screenly.io</span>
-        </span>
-      </div>
-    </aside>
+    <a
+      class="brand"
+      href="https://www.screenly.io"
+      target="_blank"
+      rel="noopener noreferrer"
+      aria-label="Screenly - opens in a new tab"
+    >
+      <img src="/static/images/screenly-logo.svg?v=${props.v}" alt="Screenly" />
+    </a>
   </div>
 
   <footer id="weather-item-list"></footer>

--- a/sync-fonts.js
+++ b/sync-fonts.js
@@ -1,41 +1,12 @@
 #!/usr/bin/env bun
-/* global Bun */
-// Copies the self-hosted webfont files out of the Bun-managed @fontsource
-// packages and into ./assets/static/fonts, where wrangler's [site] config
-// serves them at /static/fonts/. Bun owns the font versions (package.json);
-// this step vendors the exact files we ship and serve ourselves — no CDN.
-//
-// Fonts: Fraunces (display serif, "standard" axis = opsz + wght, normal +
-// italic) for the temperature/condition; Hanken Grotesk for metadata.
+// Vendor this app's webfonts into ./assets/static/fonts. The files, versions,
+// and copy logic all live in @screenly-labs/signage-kit — this just names the
+// families the weather display uses (Fraunces + Hanken Grotesk).
 
-const FONTS = [
-  '@fontsource-variable/fraunces/files/fraunces-latin-standard-normal.woff2',
-  '@fontsource-variable/fraunces/files/fraunces-latin-standard-italic.woff2',
-  '@fontsource-variable/hanken-grotesk/files/hanken-grotesk-latin-wght-normal.woff2'
-]
-const DEST_DIR = 'assets/static/fonts'
+import { syncFonts } from '@screenly-labs/signage-kit/sync-fonts'
 
-export const run = async () => {
-  let count = 0
+export const run = () => syncFonts(['fraunces', 'hanken-grotesk'])
 
-  for (const rel of FONTS) {
-    const file = rel.split('/').pop()
-    const src = Bun.file(`node_modules/${rel}`)
-
-    if (!(await src.exists())) {
-      console.error(`✗ Missing ${file} — run \`bun install\` first.`)
-      process.exit(1)
-    }
-
-    await Bun.write(`${DEST_DIR}/${file}`, src)
-    console.log(`✓ Font: ${DEST_DIR}/${file}`)
-    count++
-  }
-
-  console.log(`Fonts synced — ${count} file(s) vendored from @fontsource.`)
-}
-
-// Allow running standalone: `bun run sync-fonts.js`
 if (import.meta.main) {
   await run()
 }


### PR DESCRIPTION
Promotes the 2026.7.2 adoption (CTA→badge + fonts) from master to production. Validated on stage-weather.srly.io: fonts load from the kit, the fixed corner badge renders bottom-right (CTA banner + GA device event removed), design unchanged across the resolution matrix, degraded legible, badge removed under screenly-viewer UA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)