### PR TITLE
Document that `bun run dev` does not render like production

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,6 +62,15 @@ Therefore all unit-testable pure helpers (locale resolution, temp conversion, ti
 
 `build.js` minifies JS/CSS **in place**, overwriting the source files in `assets/`. It also vendors webfonts from `@fontsource` packages into `assets/static/fonts/` (no CDN). Don't run `bun run build` and commit the minified output as if it were source.
 
+### `bun run dev` does not render what production renders
+
+`bun run dev` runs `build.js --client`, which skips the CSS step. That step is what prepends signage-kit's `styles/fonts.css` + `styles/brand.css` into `main.css` (a raw-CSS Worker can't resolve a bare `@import`). `main.css` therefore carries **no `@font-face` and no `.brand` rules of its own** in source, and the dev server serves it that way. Two consequences, both of which look like app bugs:
+
+- **No webfonts load.** Everything falls back to system fonts, so text metrics (and therefore wrapping, line counts and overflow) are wrong.
+- **`.brand` is unstyled.** It should be a `position: fixed` ~116px footer badge; unstyled it is a ~1650px block that stretches the `.content` grid column, dragging `.midrow` and `#weather-item-list` past the viewport where `overflow: hidden` silently clips them. In portrait this hides a forecast item entirely.
+
+So don't trust `bun run dev` for anything visual, and never conclude a layout bug from it. To check rendering for real, either screenshot production (`weather.srly.io`), or run a full `bun run build`, verify, then `git checkout -- assets/` to undo the in-place minification (see above). When measuring layout in a headless browser, assert `document.fonts.check('1rem "Hanken Grotesk"')` first, and check clipping on `.content` (it has `overflow: hidden`, so a too-wide child is cut rather than scrolling `documentElement`).
+
 ## Conventions
 
 - **Biome** is the linter+formatter (config in `biome.json`): single quotes, no semicolons, no trailing commas, 2-space indent, 100-col width. `bun run lint` fails on warnings.


### PR DESCRIPTION
## Why

`bun run dev` runs `build.js --client`, which skips the CSS step. That step is what prepends signage-kit's `styles/fonts.css` + `styles/brand.css` into `main.css` (a raw-CSS Worker can't resolve a bare `@import`), so `main.css` holds no `@font-face` and no `.brand` rules of its own in source. The dev server serves it exactly that way.

The failure mode is nasty because it presents as an app bug, not a build gap:

- **No webfonts load.** Everything silently falls back to system fonts, so text metrics — and therefore wrapping, line counts and overflow measurements — are wrong.
- **`.brand` renders unstyled** at ~1650px intrinsic width instead of the `position: fixed` ~116px footer badge. That stretches the implicit column of `.content` (`display: grid`), dragging `.midrow` and `#weather-item-list` past the viewport, where `overflow: hidden` clips them silently. In portrait it hides a forecast item entirely.

## How I found it

While verifying #75 I "found" a portrait layout bug: the `20:00` forecast item was missing and the Screenly wordmark was enormous and clipped. I was about to fix it. Screenshotting production instead settled it in one shot:

```
.brand    : position=fixed rect={"x":930,"w":116,"right":1045}   <- correct badge
list rect : {"x":39,"w":1002,"right":1041}  content.scrollWidth=1080  <- fits
items     : Current | 17:00 | 20:00 | 23:00 | 2:00   <- all five present
fonts     : Hanken Grotesk:loaded, Fraunces:loaded
```

No such bug exists in production. It cost a full investigation into a phantom, plus a round of layout measurements taken against the wrong fonts (the same string wrapped to 4 lines under fallbacks vs 2 with real Fraunces), which had to be thrown away and re-run.

## What this adds

A short section under "Build is destructive" stating the caveat, how to check rendering for real (screenshot production, or a full `bun run build` then `git checkout -- assets/` to undo the in-place minification), and the two assertions that would have caught it immediately:

- `document.fonts.check('1rem "Hanken Grotesk"')` before trusting any measurement
- test clipping on `.content`, not `documentElement` — `.content` has `overflow: hidden`, so a too-wide child is cut rather than scrolling the document, which is exactly why my first overflow check came back clean

Docs only, no code change. Every claim was verified against the tree before writing: the `dev` script's `--client` flag, zero `.brand` rules in the CSS source, and `.content { overflow: hidden }`.

Related: #75, which is where this bit me.

🤖 Generated with [Claude Code](https://claude.com/claude-code)