### PR TITLE
Release: localize the weather description (verified on stage)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,6 +62,15 @@ Therefore all unit-testable pure helpers (locale resolution, temp conversion, ti
 
 `build.js` minifies JS/CSS **in place**, overwriting the source files in `assets/`. It also vendors webfonts from `@fontsource` packages into `assets/static/fonts/` (no CDN). Don't run `bun run build` and commit the minified output as if it were source.
 
+### `bun run dev` does not render what production renders
+
+`bun run dev` runs `build.js --client`, which skips the CSS step. That step is what prepends signage-kit's `styles/fonts.css` + `styles/brand.css` into `main.css` (a raw-CSS Worker can't resolve a bare `@import`). `main.css` therefore carries **no `@font-face` and no `.brand` rules of its own** in source, and the dev server serves it that way. Two consequences, both of which look like app bugs:
+
+- **No webfonts load.** Everything falls back to system fonts, so text metrics (and therefore wrapping, line counts and overflow) are wrong.
+- **`.brand` is unstyled.** It should be a `position: fixed` ~116px footer badge; unstyled it is a ~1650px block that stretches the `.content` grid column, dragging `.midrow` and `#weather-item-list` past the viewport where `overflow: hidden` silently clips them. In portrait this hides a forecast item entirely.
+
+So don't trust `bun run dev` for anything visual, and never conclude a layout bug from it. To check rendering for real, either screenshot production (`weather.srly.io`), or run a full `bun run build`, verify, then `git checkout -- assets/` to undo the in-place minification (see above). When measuring layout in a headless browser, assert `document.fonts.check('1rem "Hanken Grotesk"')` first, and check clipping on `.content` (it has `overflow: hidden`, so a too-wide child is cut rather than scrolling `documentElement`).
+
 ## Conventions
 
 - **Biome** is the linter+formatter (config in `biome.json`): single quotes, no semicolons, no trailing commas, 2-space indent, 100-col width. `bun run lint` fails on warnings.

--- a/assets/static/js/locale.js
+++ b/assets/static/js/locale.js
@@ -173,16 +173,36 @@ export const setLocaleOverride = (value) => {
 
 export const setLocale = (code) => applyLocale(localeOverride || resolveLocale(code))
 
-// OpenWeatherMap's `lang` codes are mostly the ISO-639-1 subtag, but a few
-// predate it and disagree. Only the codes owmLang can actually emit are listed,
-// i.e. Latin-script ones; OWM's non-Latin oddities (kr, ua, zh_cn, zh_tw) are
-// deliberately absent because the script guard below never lets them through.
-// An unlisted language passes through as its bare subtag, which OWM either
-// translates or quietly answers in English - the same as sending nothing.
-//   cs -> cz  OWM predates the ISO code for Czech.
-//   lv -> la  'la' is really Latin, but OWM uses it for Latvian.
-//   nb -> no  CLDR maximizes NO to nb-NO (Bokmal); OWM only knows plain 'no'.
-const OWM_LANG = { cs: 'cz', lv: 'la', nb: 'no', nn: 'no' }
+// BCP-47 language subtag -> OpenWeatherMap `lang` code, for the languages OWM
+// documents that also render in Latin script. Anything absent stays English.
+//
+// This is an explicit allowlist, NOT "pass the subtag through and let OWM cope",
+// because the returned text gets tagged with the language we believe it is in
+// (see descriptionLocale). OWM answers an unknown code with English instead of
+// erroring, so passing one through would leave us labelling English text as
+// Estonian and stripping its title case. Only a language OWM actually
+// translates may be requested, and only then is the result tagged.
+//
+// Most map to themselves; the exceptions are OWM's own inventions:
+//   cs -> cz     OWM predates the ISO code for Czech.
+//   lv -> la     'la' is really Latin, but OWM uses it for Latvian.
+//   nb/nn -> no  CLDR maximizes NO to nb-NO (Bokmal); OWM only knows plain 'no'.
+// Deliberately absent:
+//   en           OWM's own default, so requesting it is a no-op. Leaving it out
+//                keeps English untagged and title-cased, exactly as it renders
+//                on the auto-detected path.
+//   sr, and the Cyrillic/CJK/RTL codes (kr, ua, ru, zh_cn, ...)
+//                OWM translates Serbian into Cyrillic, which the Latin-only
+//                fonts cannot render even when the *locale* is sr-Latn. The
+//                rest never survive the script guard below anyway.
+// Adding a language OWM later supports is additive; until then it stays English.
+const OWM_LANG = {
+  af: 'af', az: 'az', ca: 'ca', cs: 'cz', da: 'da', de: 'de', es: 'es', eu: 'eu',
+  fi: 'fi', fr: 'fr', gl: 'gl', hr: 'hr', hu: 'hu', id: 'id', is: 'is', it: 'it',
+  ku: 'ku', lt: 'lt', lv: 'la', nb: 'no', nl: 'nl', nn: 'no', no: 'no', pl: 'pl',
+  pt: 'pt', ro: 'ro', sk: 'sk', sl: 'sl', sq: 'sq', sv: 'sv', tr: 'tr', vi: 'vi',
+  zu: 'zu'
+}
 // Languages OWM translates per-region rather than per-language.
 const OWM_LANG_BY_TAG = { 'pt-BR': 'pt_br' }
 
@@ -208,7 +228,8 @@ export const owmLang = (tag) => {
   if (!tag || !isLatinScript(tag)) return ''
   try {
     const { language, region } = new Intl.Locale(tag)
-    return OWM_LANG_BY_TAG[`${language}-${region}`] || OWM_LANG[language] || language
+    // Falls back to '' (English), never to the bare subtag: see OWM_LANG.
+    return OWM_LANG_BY_TAG[`${language}-${region}`] || OWM_LANG[language] || ''
   } catch {
     return ''
   }

--- a/assets/static/js/locale.js
+++ b/assets/static/js/locale.js
@@ -173,6 +173,54 @@ export const setLocaleOverride = (value) => {
 
 export const setLocale = (code) => applyLocale(localeOverride || resolveLocale(code))
 
+// OpenWeatherMap's `lang` codes are mostly the ISO-639-1 subtag, but a few
+// predate it and disagree. Only the codes owmLang can actually emit are listed,
+// i.e. Latin-script ones; OWM's non-Latin oddities (kr, ua, zh_cn, zh_tw) are
+// deliberately absent because the script guard below never lets them through.
+// An unlisted language passes through as its bare subtag, which OWM either
+// translates or quietly answers in English - the same as sending nothing.
+//   cs -> cz  OWM predates the ISO code for Czech.
+//   lv -> la  'la' is really Latin, but OWM uses it for Latvian.
+//   nb -> no  CLDR maximizes NO to nb-NO (Bokmal); OWM only knows plain 'no'.
+const OWM_LANG = { cs: 'cz', lv: 'la', nb: 'no', nn: 'no' }
+// Languages OWM translates per-region rather than per-language.
+const OWM_LANG_BY_TAG = { 'pt-BR': 'pt_br' }
+
+// True when a locale renders in the Latin alphabet, per CLDR likely-subtags
+// rather than a hand-listed set of languages.
+const isLatinScript = (tag) => {
+  try {
+    return new Intl.Locale(tag).maximize().script === 'Latn'
+  } catch {
+    return false
+  }
+}
+
+// OWM `lang` code for the weather description, or '' to leave it in English.
+// The description is the one string we cannot format ourselves, so it has to be
+// requested in the right language upstream (see the weather route).
+//
+// Non-Latin-script locales deliberately stay English: the vendored fonts ship
+// latin subsets only (see build.js), so a Cyrillic/CJK/Arabic description would
+// render as tofu on a live screen. This is the same reasoning as LOCALE_OVERRIDES
+// above, applied to the one field that comes from upstream instead of from Intl.
+export const owmLang = (tag) => {
+  if (!tag || !isLatinScript(tag)) return ''
+  try {
+    const { language, region } = new Intl.Locale(tag)
+    return OWM_LANG_BY_TAG[`${language}-${region}`] || OWM_LANG[language] || language
+  } catch {
+    return ''
+  }
+}
+
+// The OWM `lang` for the *current* display locale, i.e. what the description
+// should be translated into. Only a ?locale override is known early enough to
+// influence the fetch; without one the locale is derived from the country in the
+// response body, by which point the description has already been fetched, so the
+// auto-detected case keeps OWM's English default.
+export const descriptionLang = () => owmLang(localeOverride)
+
 // ISO-3166 region subtag of a BCP-47 tag ('en-US' -> 'US', 'zh-Hant-TW' -> 'TW',
 // 'ha-Latn-NG' -> 'NG'), or '' when the tag carries no region ('ar', 'fr') or is
 // malformed. Uses the built-in Intl.Locale parser rather than a hand-rolled one.

--- a/assets/static/js/locale.js
+++ b/assets/static/js/locale.js
@@ -221,6 +221,13 @@ export const owmLang = (tag) => {
 // auto-detected case keeps OWM's English default.
 export const descriptionLang = () => owmLang(localeOverride)
 
+// The BCP-47 tag the description was actually translated into, or '' when it is
+// OWM's English default. This is deliberately NOT the OWM code: 'cz' and 'la'
+// are OWM's own inventions (Czech is really 'cs', Latvian 'lv'), so feeding them
+// to a lang attribute would mislabel the text. Drives the casing rule in the CSS
+// - English title-cases the description, German capitalizes only its nouns.
+export const descriptionLocale = () => (descriptionLang() ? localeOverride : '')
+
 // ISO-3166 region subtag of a BCP-47 tag ('en-US' -> 'US', 'zh-Hant-TW' -> 'TW',
 // 'ha-Latn-NG' -> 'NG'), or '' when the tag carries no region ('ar', 'fr') or is
 // malformed. Uses the built-in Intl.Locale parser rather than a hand-rolled one.

--- a/assets/static/js/main.src.js
+++ b/assets/static/js/main.src.js
@@ -10,6 +10,7 @@ import {
   setLocale,
   setLocaleOverride,
   setTimeFormat,
+  descriptionLang,
   getTimeByOffset,
   formatTime,
   formatDate,
@@ -298,7 +299,12 @@ import {
     clearTimeout(refreshTimer)
     try {
       const { lat, lng } = getLocation()
-      const response = await fetch(`/api/weather?lat=${lat}&lng=${lng}`)
+      const params = new URLSearchParams({ lat, lng })
+      // Ask upstream for the description in the display language; omitted when
+      // there is no ?locale override, or for scripts the fonts cannot render.
+      const lang = descriptionLang()
+      if (lang) params.set('lang', lang)
+      const response = await fetch(`/api/weather?${params.toString()}`)
       const data = await response.json()
       updateData(data)
     } catch (e) {

--- a/assets/static/js/main.src.js
+++ b/assets/static/js/main.src.js
@@ -11,6 +11,7 @@ import {
   setLocaleOverride,
   setTimeFormat,
   descriptionLang,
+  descriptionLocale,
   getTimeByOffset,
   formatTime,
   formatDate,
@@ -175,6 +176,14 @@ import {
   const updateCurrentWeather = (icon, desc, temp) => {
     updateAttribute('current-weather-icon', 'src', withVersion(`${iconsPath}/${icon}.svg`))
     updateContent('current-weather-status', desc)
+    // Tag the description with the language it was translated into, so the CSS
+    // stops title-casing it (English convention, wrong for German) and assistive
+    // tech reads it correctly. Cleared when OWM answered in English, so its
+    // default is never mislabelled as the display locale.
+    const status = document.querySelector('#current-weather-status')
+    const descLocale = descriptionLocale()
+    if (descLocale) status.lang = descLocale
+    else status.removeAttribute('lang')
     updateContent('current-temp', getTemp(temp))
     // The degree sign is a static element; the scale element holds just C/F.
     updateContent('current-temp-scale', tempScale)

--- a/assets/static/styles/main.css
+++ b/assets/static/styles/main.css
@@ -207,8 +207,24 @@ body[data-night="true"]        { --accent: #b6a6f2; }
   flex: none;
 }
 
+/* OWM sends the description lowercase ("broken clouds"), so title-case it. */
 #current-weather-status {
   text-transform: capitalize;
+}
+
+/* main.js tags the description with its language once it is actually translated.
+   Title case is an English convention: German capitalizes nouns and nothing
+   else, so `capitalize` would render "Gewitter Mit Leichtem Regen" for what OWM
+   correctly sent as "Gewitter mit leichtem Regen". Keep the upstream casing and
+   lift only the first letter, since OWM still sends some of it lowercase
+   ("überwiegend bewölkt" -> "Überwiegend bewölkt"). Untagged text is OWM's
+   English default and keeps the title case above. */
+#current-weather-status[lang] {
+  text-transform: none;
+}
+
+#current-weather-status[lang]::first-letter {
+  text-transform: uppercase;
 }
 
 .temperature {

--- a/src/routes/weather.js
+++ b/src/routes/weather.js
@@ -7,7 +7,7 @@ const UPSTREAM_TIMEOUT_MS = 10000
 
 weather.get('/', async (c) => {
   try {
-    const { lat = defaultLocation.lat, lng = defaultLocation.lng } = c.req.query()
+    const { lat = defaultLocation.lat, lng = defaultLocation.lng, lang } = c.req.query()
     const params = new URLSearchParams({
       lat,
       lon: lng,
@@ -15,6 +15,12 @@ weather.get('/', async (c) => {
       cnt: '10',
       appid: c.env.OPEN_WEATHER_API_KEY
     })
+    // Translate the weather description upstream; the client derives the code
+    // from its display locale (see owmLang in locale.js) and omits it to keep
+    // OWM's English default. Shape-checked rather than matched against OWM's
+    // language list: an unknown-but-well-formed code just yields English, and
+    // hardcoding the list here would leave it to rot on their next addition.
+    if (lang && /^[a-z]{2}(_[a-z]{2})?$/.test(lang)) params.set('lang', lang)
     const apiUrl = `https://api.openweathermap.org/data/2.5/forecast?${params.toString()}`
 
     const timeoutMs = Number(c.env.WEATHER_TIMEOUT_MS) || UPSTREAM_TIMEOUT_MS

--- a/src/routes/weather.test.js
+++ b/src/routes/weather.test.js
@@ -45,6 +45,38 @@ describe('Weather route', () => {
     expect(url.searchParams.get('units')).toBe('metric')
   })
 
+  it('forwards a well-formed lang so the description is translated upstream', async () => {
+    let capturedUrl
+    globalThis.fetch = async (url) => {
+      capturedUrl = url
+      return json({})
+    }
+
+    await call('http://localhost/?lat=51.44&lng=7.08&lang=de')
+    expect(new URL(capturedUrl).searchParams.get('lang')).toBe('de')
+
+    // OWM's region-specific codes carry an underscore.
+    await call('http://localhost/?lat=51.44&lng=7.08&lang=pt_br')
+    expect(new URL(capturedUrl).searchParams.get('lang')).toBe('pt_br')
+  })
+
+  it('omits lang when absent or malformed, leaving the description English', async () => {
+    let capturedUrl
+    globalThis.fetch = async (url) => {
+      capturedUrl = url
+      return json({})
+    }
+
+    await call('http://localhost/?lat=51.44&lng=7.08')
+    expect(new URL(capturedUrl).searchParams.has('lang')).toBe(false)
+
+    // Junk must not reach upstream or fan out the cache key.
+    for (const junk of ['DE', 'de-DE', 'x'.repeat(50), '../evil', '']) {
+      await call(`http://localhost/?lat=51.44&lng=7.08&lang=${encodeURIComponent(junk)}`)
+      expect(new URL(capturedUrl).searchParams.has('lang')).toBe(false)
+    }
+  })
+
   it('returns 502 when the upstream responds with a non-OK status', async () => {
     globalThis.fetch = async () => json({ cod: 401, message: 'Invalid API key.' }, 401)
 

--- a/test/locale.test.js
+++ b/test/locale.test.js
@@ -267,8 +267,8 @@ describe('owmLang (weather-description language)', () => {
   it('maps a locale to its OpenWeatherMap language code', () => {
     expect(owmLang('de-DE')).toBe('de') // the reported bug: German description
     expect(owmLang('fr-FR')).toBe('fr')
-    expect(owmLang('en-GB')).toBe('en')
     expect(owmLang('de')).toBe('de') // region-less tags still resolve
+    // en-GB deliberately yields '' - see the dedicated English case below.
   })
 
   it("uses OWM's non-standard codes where they differ from ISO-639-1", () => {
@@ -299,6 +299,39 @@ describe('owmLang (weather-description language)', () => {
     expect(owmLang(undefined)).toBe('')
     expect(owmLang('zzzzz')).toBe('')
     expect(owmLang('not a tag')).toBe('')
+  })
+
+  it('stays English for Latin-script languages OWM does not translate', () => {
+    // OWM answers an unknown code with English rather than erroring, so emitting
+    // one would leave the UI tagging English text as this language (and dropping
+    // its title case). Only codes OWM documents may be requested.
+    expect(owmLang('et-EE')).toBe('') // Estonian: 2 letters, passes the route's
+    //                                   shape check, but OWM has no Estonian.
+    expect(owmLang('fil-PH')).toBe('') // 3-letter subtag the route would drop
+    expect(owmLang('haw-US')).toBe('')
+    expect(owmLang('ceb-PH')).toBe('')
+  })
+
+  it('does not request English, since that is already OWM\'s default', () => {
+    // Requesting lang=en is a no-op upstream, and tagging the result would strip
+    // the title case that the auto-detected English path keeps.
+    expect(owmLang('en-GB')).toBe('')
+    expect(owmLang('en-US')).toBe('')
+  })
+
+  it('emits only codes the weather route will forward', () => {
+    // Mirror of the shape check in src/routes/weather.js: anything owmLang emits
+    // must survive it, or the client would tag text the server left untranslated.
+    const routeShape = /^[a-z]{2}(_[a-z]{2})?$/
+    const tags = [
+      'de-DE', 'fr-FR', 'pt-BR', 'pt-PT', 'cs-CZ', 'lv-LV', 'nb-NO', 'sq-AL',
+      'is-IS', 'az-AZ', 'ku-TR', 'sv-SE', 'es-ES', 'id-ID', 'zu-ZA', 'vi-VN'
+    ]
+    for (const tag of tags) {
+      const code = owmLang(tag)
+      expect(code).not.toBe('')
+      expect(routeShape.test(code)).toBe(true)
+    }
   })
 })
 

--- a/test/locale.test.js
+++ b/test/locale.test.js
@@ -15,6 +15,7 @@ import {
   resolveHour12,
   owmLang,
   descriptionLang,
+  descriptionLocale,
   formatTime,
   formatDate,
   getTimeByOffset,
@@ -320,5 +321,35 @@ describe('descriptionLang (fetch-time language)', () => {
   it('ignores an unsupported override, matching the rest of the display', () => {
     setLocaleOverride('zzzzz')
     expect(descriptionLang()).toBe('')
+  })
+})
+
+describe('descriptionLocale (casing / lang tag)', () => {
+  afterEach(() => setLocaleOverride(''))
+
+  it('reports the BCP-47 tag, never OWM\'s invented code', () => {
+    // The lang attribute must be a real language subtag. OWM calls Czech 'cz'
+    // and Latvian 'la'; tagging the DOM with those would mislabel the text.
+    setLocaleOverride('cs-CZ')
+    expect(descriptionLang()).toBe('cz') // what we send upstream
+    expect(descriptionLocale()).toBe('cs-CZ') // what the DOM gets
+    setLocaleOverride('lv-LV')
+    expect(descriptionLang()).toBe('la')
+    expect(descriptionLocale()).toBe('lv-LV')
+  })
+
+  it('tags a translated description', () => {
+    setLocaleOverride('de-DE')
+    expect(descriptionLocale()).toBe('de-DE')
+  })
+
+  it('leaves an English description untagged, so it keeps title case', () => {
+    // Auto-detect and non-Latin scripts both keep OWM's English default; marking
+    // those as de-DE/ru-RU would be a lie and would drop the title casing.
+    setLocaleOverride('')
+    setLocale('DE')
+    expect(descriptionLocale()).toBe('')
+    setLocaleOverride('ru-RU')
+    expect(descriptionLocale()).toBe('')
   })
 })

--- a/test/locale.test.js
+++ b/test/locale.test.js
@@ -13,6 +13,8 @@ import {
   setLocaleOverride,
   setTimeFormat,
   resolveHour12,
+  owmLang,
+  descriptionLang,
   formatTime,
   formatDate,
   getTimeByOffset,
@@ -257,5 +259,66 @@ describe('getCondCategory (weather-reactive accent)', () => {
     expect(getCondCategory(741)).toBe('haze')
     expect(getCondCategory(800)).toBe('clear')
     expect(getCondCategory(802)).toBe('clouds')
+  })
+})
+
+describe('owmLang (weather-description language)', () => {
+  it('maps a locale to its OpenWeatherMap language code', () => {
+    expect(owmLang('de-DE')).toBe('de') // the reported bug: German description
+    expect(owmLang('fr-FR')).toBe('fr')
+    expect(owmLang('en-GB')).toBe('en')
+    expect(owmLang('de')).toBe('de') // region-less tags still resolve
+  })
+
+  it("uses OWM's non-standard codes where they differ from ISO-639-1", () => {
+    expect(owmLang('cs-CZ')).toBe('cz')
+    expect(owmLang('lv-LV')).toBe('la')
+    // Albanian is 'sq' in OWM's table too, so it must NOT be rewritten to 'al'.
+    expect(owmLang('sq-AL')).toBe('sq')
+    // CLDR maximizes NO to nb-NO, but OWM only documents plain 'no'.
+    expect(owmLang('nb-NO')).toBe('no')
+    expect(owmLang('no')).toBe('no')
+  })
+
+  it('distinguishes the region-specific variants OWM translates separately', () => {
+    expect(owmLang('pt-BR')).toBe('pt_br')
+    expect(owmLang('pt-PT')).toBe('pt')
+  })
+
+  it('keeps non-Latin scripts English, since the vendored fonts are latin-only', () => {
+    expect(owmLang('ru-RU')).toBe('') // Cyrillic
+    expect(owmLang('ja-JP')).toBe('') // CJK
+    expect(owmLang('zh-CN')).toBe('')
+    expect(owmLang('ar-SA')).toBe('') // RTL
+    expect(owmLang('el-GR')).toBe('') // Greek
+  })
+
+  it('falls back to English for missing or malformed tags', () => {
+    expect(owmLang('')).toBe('')
+    expect(owmLang(undefined)).toBe('')
+    expect(owmLang('zzzzz')).toBe('')
+    expect(owmLang('not a tag')).toBe('')
+  })
+})
+
+describe('descriptionLang (fetch-time language)', () => {
+  afterEach(() => setLocaleOverride(''))
+
+  it('translates the description for a ?locale override', () => {
+    setLocaleOverride('de-DE')
+    expect(descriptionLang()).toBe('de')
+  })
+
+  it('leaves the description English when the locale is auto-detected', () => {
+    // Without an override the locale is only known once the country arrives in
+    // the response body, which is after the description has been fetched.
+    setLocaleOverride('')
+    setLocale('DE')
+    expect(descriptionLang()).toBe('')
+  })
+
+  it('ignores an unsupported override, matching the rest of the display', () => {
+    setLocaleOverride('zzzzz')
+    expect(descriptionLang()).toBe('')
   })
 })


### PR DESCRIPTION
Promotes master to production. Contents are exactly the 6 commits below, all from the German-description fix. Nothing else is riding along.

## What this fixes

Reported: https://weather.srly.io/?lat=51.4429&lng=7.0801&locale=de-DE&24h=1 renders the weekday in German but the weather description in English.

`src/routes/weather.js` never sent OpenWeatherMap a `lang` parameter. Everything the app formats itself (city, date, time) goes through `Intl` and already followed the locale; the description is the one field passed verbatim from upstream, so it was the one field that never localized.

## Verified on stage, not just in tests

This is the part that could never be checked locally (no OWM key in dev). Against the real stage deploy, real API key, real built CSS:

| Case | Client requests | Renders |
|---|---|---|
| `?locale=de-DE` | `...&lang=de` | **`Überwiegend bewölkt`** ✅ |
| `?locale=fr-FR` | `...&lang=fr` | **`nuageux`** ✅ |
| no `?locale` | `...` (no lang) | `broken clouds`, title-cased (unchanged) ✅ |

Screenshotted at 1920x1080 and 1080x1920. Both orientations: webfonts loaded (`hanken=true fraunces=true`), `.brand` badge `position: fixed`, no clipping, no overflow in either axis, no collision with the temperature, all 5 forecast items present, no JS errors.

## Commits

- `549f465` Localize the weather description via OWM's lang param
- `e9f52eb` Stop title-casing translated descriptions (German capitalizes nouns, not every word, so `capitalize` rendered "Gewitter **Mit Leichtem** Regen")
- `c0f771a` Only request OWM languages it actually translates (from Copilot review)
- `074ad7c` Document that `bun run dev` does not render like production
- merges of #75, #76

## Scope limits (deliberate, not regressions)

- **Override only.** `lang` is sent only when `?locale` is set. Without it the locale comes from the country in the response body, which is not known until after the description is fetched, so that path keeps OWM's English default. A German viewer with no `?locale` still sees an English description.
- **Latin-script only.** `ru-RU`, `ja-JP`, `zh-CN`, `ar-SA` keep English descriptions: the vendored fonts ship latin subsets only.
- **English is byte-for-byte unchanged** on both the auto-detect and explicit `?locale=en-*` paths.

## One thing to know at deploy time

`/api/weather` responses are edge-cached for 3h, keyed by full URL including `lang`. A request made during the deploy window can pin an English response under the `lang=de` key for up to 3h. I hit exactly this on stage: the first `lang=de` request returned English (`cf-cache-status: HIT`), while a fresh key returned German immediately. It self-heals within 3h and needs no action, but if you want it immediate, purge the cache for `/api/weather*` after deploy.

Copilot reviewed and CI is green on both source PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)