### PR TITLE
Show old-Anthias players a free-upgrade notice

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@ worker
 
 # Built client bundle (compiled from assets/static/js/main.src.js by build.js)
 assets/static/js/main.js
+
+# Stale-player QR, encoded by build.js from UPGRADE_URL in stale-player.js
+assets/static/images/anthias-upgrade-qr.svg
 .dev.vars
 .wrangler
 package-lock.json

--- a/assets/static/js/main.src.js
+++ b/assets/static/js/main.src.js
@@ -3,6 +3,8 @@
 // shim is in place before any render.
 import '@screenly-labs/signage-kit/polyfills'
 import { removeScreenlyBranding } from '@screenly-labs/signage-kit/branding'
+import { detectPlayer } from '@screenly-labs/signage-kit/profiler'
+import { mountStaleNotice } from './stale-player.js'
 import {
   usesFahrenheit,
   unitsCountry,
@@ -335,6 +337,11 @@ import {
     // fetchWeather() reschedules itself every 2 hours.
     fetchWeather()
     removeScreenlyBranding()
+    // Warn old-Anthias viewers that their player is out of date. Client-side on
+    // purpose: the SSR page cache is keyed by asset version + coordinates and
+    // carries no user-agent component, so a server-rendered notice would be
+    // cached and then served to every player regardless of what it is running.
+    mountStaleNotice(detectPlayer(), document, assetVersion)
   }
 
   // Only auto-run in a real browser; under a test runner there is no document.

--- a/assets/static/js/stale-player.js
+++ b/assets/static/js/stale-player.js
@@ -54,9 +54,13 @@ export const createStaleNotice = (doc, v) => {
   const el = doc.createElement('aside')
   el.className = 'stale-notice'
   el.id = 'stale-notice'
-  // Not aria-live: on unattended signage there is no user to announce to, and
-  // the notice is present from first paint rather than arriving as an update.
-  el.setAttribute('role', 'status')
+  // `note`, deliberately not `status`: status is an implicit aria-live="polite"
+  // region, and there is nothing here to announce. The notice is present from
+  // first paint rather than arriving as an update, so a live region would only
+  // interrupt to read out content already sitting on the page. `note` also
+  // overrides the `complementary` landmark <aside> would otherwise carry, which
+  // overstates a corner tag as a page-level region.
+  el.setAttribute('role', 'note')
 
   const text = doc.createElement('p')
   text.className = 'stale-notice-text'

--- a/assets/static/js/stale-player.js
+++ b/assets/static/js/stale-player.js
@@ -1,0 +1,86 @@
+// Stale-player notice: warns viewers whose player is an old Anthias build, and
+// points them at the free upgrade with a QR code. Kept out of main.src.js so the
+// predicate can be unit-tested with a real ES module import — main.src.js bundles
+// this in and must stay export-free (see the build note in main.src.js).
+
+// An untagged QtWebEngine player IS an old Anthias — that is the call this app
+// makes, and the copy names Anthias on the strength of it.
+//
+// Don't "correct" this to `vendor === 'anthias'`. signage-kit's profiler sets
+// that vendor only on the explicit `Anthias/` UA token, which is precisely what
+// the old builds we are trying to reach do not send — so the obvious-looking
+// test matches every player except the ones the notice exists for. Every other
+// QtWebEngine player identifies itself, which is what makes the residual
+// untagged bucket attributable:
+//
+//   old Anthias   QtWebEngine/5.15.2 Chrome/83  -> vendor null    (untagged)
+//   current       QtWebEngine/6.8.2  Chrome/122 -> vendor 'anthias'
+//   Screenly      ... screenly-viewer           -> vendor 'screenly'
+//   BrightSign    QtWebEngine/5.11.2 Chrome/65  -> vendor 'brightsign'
+//
+// Engine age is deliberately NOT part of the test either. Sending the token is
+// itself the mark of a current build, so an untagged player is out of date
+// whichever Chromium it carries — gating on belowFloor as well would miss a
+// build new enough to have reached Qt6 but still too old to identify itself.
+export const isStalePlayer = (profile) =>
+  profile.vendor === null && profile.engine.name === 'qtwebengine'
+
+// The sign speaks for itself — first person is what makes an unattended screen
+// asking to be fixed land as friendly rather than as an error dialog. Note what
+// it does NOT say: no version number and no year, because the UA only tells us
+// the player is untagged, not how old it is. "from years ago" is the strongest
+// claim the detection actually supports.
+export const STALE_MESSAGE =
+  "Psst — I'm still running Anthias from years ago. Nobody's updated me in a while. Scan to fix that, free."
+
+// Where the QR points. build.js encodes this exact string into the SVG at build
+// time, so the image and the link can never disagree.
+//
+// UTM medium is `qr` because that is literally the only way this link is ever
+// followed — it is never clickable, so a scan is the whole channel. The campaign
+// matches the clock app's verbatim, on purpose: it is one cross-app push at the
+// same audience, and the useful question is how many stale players upgraded in
+// total, with utm_source splitting that by which app did the telling.
+export const UPGRADE_URL =
+  'https://anthias.screenly.io/get-started/?utm_source=weather-app&utm_medium=qr&utm_campaign=anthias-stale-player'
+
+export const QR_SRC = '/static/images/anthias-upgrade-qr.svg'
+
+// Build the notice element. Kept separate from the profile check so the copy and
+// the markup are testable without a profiler round-trip. `v` is the asset
+// version — the QR is served from a versioned URL like every other asset, so it
+// picks up the immutable 1-year cache rather than the 5-minute legacy TTL.
+export const createStaleNotice = (doc, v) => {
+  const el = doc.createElement('aside')
+  el.className = 'stale-notice'
+  el.id = 'stale-notice'
+  // Not aria-live: on unattended signage there is no user to announce to, and
+  // the notice is present from first paint rather than arriving as an update.
+  el.setAttribute('role', 'status')
+
+  const text = doc.createElement('p')
+  text.className = 'stale-notice-text'
+  text.textContent = STALE_MESSAGE
+
+  const qr = doc.createElement('img')
+  qr.className = 'stale-notice-qr'
+  qr.src = v ? `${QR_SRC}?v=${v}` : QR_SRC
+  // The URL is in the alt text because a camera is the only way to act on the
+  // QR — a viewer who cannot see the image still gets somewhere to type.
+  qr.alt = `Upgrade instructions: ${UPGRADE_URL}`
+  qr.width = 96
+  qr.height = 96
+
+  el.appendChild(text)
+  el.appendChild(qr)
+  return el
+}
+
+// Mount the notice when the profile warrants it. Returns true when it mounted,
+// so the caller (and the tests) can tell the no-op case apart.
+export const mountStaleNotice = (profile, doc, v) => {
+  if (!isStalePlayer(profile)) return false
+  if (doc.querySelector('#stale-notice')) return false
+  doc.body.appendChild(createStaleNotice(doc, v))
+  return true
+}

--- a/assets/static/styles/main.css
+++ b/assets/static/styles/main.css
@@ -639,3 +639,99 @@ html.legacy .anim {
 html.legacy .weather-fx {
   display: none;
 }
+
+/* =========================================================================
+   Stale-player service tag — shown by main.js only on untagged QtWebEngine
+   players (old Anthias). Deliberately NOT part of the Observatory: the rest of
+   the page is an editorial almanac, this is a manila repair tag someone taped
+   onto it, speaking in the player's own voice. So it takes no --accent (the
+   weather-reactive colour must not absorb it into the theme), stays in the meta
+   face rather than the almanac's Fraunces, and sits still.
+
+   Written for the oldest engine in that bucket (Chromium 83, QtWebEngine 5.15):
+   no :has/nesting/color-mix. Most of these players also match html.legacy, whose
+   kill-switch strips every animation and transition — so the tag is complete at
+   rest and animates nothing, which is right for an unattended wall anyway.
+   ========================================================================= */
+.stale-notice {
+  position: fixed;
+  /* Right edge, vertically centred — the one region free in both orientations.
+     The clock app's bottom-left corner is not available here: #weather-item-list
+     is a full-width forecast rail along the bottom, and .brand holds the bottom
+     right. The midrow's right half is empty in landscape (.hero is capped at
+     32ch on the left) and in portrait (.midrow stacks bottom-left), so the tag
+     lands on the photo rather than on any reading. Verified against the live
+     site at 1080p, 720p and portrait: no overlap with the rail, hero or badge. */
+  right: clamp(1rem, 3.2vmin, 2.4rem);
+  top: 50%;
+  /* Above .content::after, the z-index:3 grain overlay — a mix-blend-mode:
+     soft-light film belongs over the photograph, not over a repair tag. That
+     also clears .brand (2) and the content rows (2). */
+  z-index: 4;
+
+  display: flex;
+  align-items: center;
+  /* Sized in rem like the rest of the sheet, so the whole tag rides the fluid
+     --root and its parts keep their proportions to each other at any
+     resolution — a vmin scale here would drift against the rem-scaled copy and
+     leave the QR stranded at 4K. */
+  gap: 0.75rem;
+  /* No width of its own — the tag shrink-wraps whatever the copy and QR need.
+     The measure is set on the text instead (see .stale-notice-text): capping the
+     tag here would leave the paragraph box at full width and open a dead gap
+     between the copy and the QR once the lines wrap. */
+  max-inline-size: 92vw;
+  padding: 0.8rem;
+
+  /* Manila stock, and the caution stripe of a condemned-equipment tag along the
+     bound edge. Fixed hex, never var(--accent): this must read as foreign. */
+  background-color: #e6d9b8;
+  border-left: 5px solid #a8431a;
+  border-radius: 2px 4px 4px 2px;
+  /* Lifted off the photo, not floating in it — a real tag casts onto the thing
+     it is stuck to. */
+  box-shadow:
+    0 2px 5px rgb(0 0 0 / 0.3),
+    0 14px 34px rgb(0 0 0 / 0.42);
+  /* The one risk: a tag hangs slightly askew. Small enough to read as physical
+     rather than as a broken transform. The centring translate must stay in this
+     same declaration to survive the rotate. */
+  transform: translateY(-50%) rotate(-1.2deg);
+}
+
+.stale-notice-text {
+  /* Ink on manila, not black on white. */
+  color: #2a2118;
+  font-family: var(--font-meta);
+  /* The px floor keeps the plea readable on a 720p Pi, where --root bottoms out. */
+  font-size: max(13px, 0.8rem);
+  font-weight: 500;
+  line-height: 1.35;
+  /* The measure lives here, on the text, so the tag can shrink to it. 30ch is
+     picked off the rendered line breaks, not by eye: at 24-26ch the copy breaks
+     as "Nobody's updated me in a / while.", orphaning the "a". 30ch resolves to
+     three clean lines with no orphan, and three lines sits better against a
+     square QR than four. Re-check the breaks if the copy changes. */
+  max-inline-size: 30ch;
+  text-wrap: balance;
+}
+
+.stale-notice-qr {
+  flex: none;
+  display: block;
+  /* 3.4rem tracks the copy's own height (3 lines x 1.35 x 0.8rem), so the code
+     reads as the same weight as the message rather than an afterthought beside
+     it. The 120px floor is a hard scannability limit, not taste: the UTM-tagged
+     URL needs a 41x41 module grid, and under ~3px per module a phone camera
+     cannot resolve it. Below ~1440p the floor is what wins and the QR sets the
+     tag's height; decoding was confirmed with zbarimg off the rendered pixels
+     at 1080p, 720p and portrait. */
+  inline-size: max(120px, 3.4rem);
+  block-size: auto;
+  /* The QR is drawn on transparent so it inherits the tag; the quiet zone is
+     padding here rather than baked into the SVG, which keeps the module grid
+     crisp at any size. */
+  padding: 0.2rem;
+  background-color: #f4ecd8;
+  border-radius: 2px;
+}

--- a/build.js
+++ b/build.js
@@ -18,6 +18,8 @@
 import { readFileSync } from 'node:fs'
 import { Glob } from 'bun'
 import { bundleJs, processCss } from '@screenly-labs/signage-kit/build'
+import QRCode from 'qrcode'
+import { QR_SRC, UPGRADE_URL } from './assets/static/js/stale-player.js'
 import { run as syncFonts } from './sync-fonts.js'
 
 const clientOnly = process.argv.includes('--client')
@@ -32,6 +34,32 @@ const sharedCss = ['fonts.css', 'brand.css']
 
 // Vendor the Bun-managed webfonts into ./assets first.
 await syncFonts()
+
+// ---- Stale-player notice QR: generated into ./assets, never committed (it is
+// a build artifact like main.js). Encoded from UPGRADE_URL in stale-player.js —
+// the same module the notice's alt text reads — so the image and the link it
+// claims to be can never drift apart. Built even under --client, because the
+// notice references the file at runtime and `bun run dev` must serve it.
+//
+// Errors at 'M' (~15% recovery): this is scanned off a wall at an angle, in
+// whatever light the room has, so it needs more margin for error than the 'L'
+// default, without the density 'Q'/'H' would add. Rendered dark-on-transparent
+// and given its light backing plate by CSS.
+const qrPath = `assets${QR_SRC}`
+try {
+  const svg = await QRCode.toString(UPGRADE_URL, {
+    type: 'svg',
+    errorCorrectionLevel: 'M',
+    margin: 0,
+    color: { dark: '#2a2118ff', light: '#00000000' }
+  })
+  await Bun.write(qrPath, svg)
+} catch (error) {
+  console.error(`✗ Failed to build ${qrPath}`)
+  console.error(error)
+  process.exit(1)
+}
+console.log(`✓ QR: ${qrPath} (${UPGRADE_URL})`)
 
 // ---- Client JS bundle: main.src.js -> main.js (inlining ./locale.js + the
 // shared polyfills shim), a self-contained IIFE at the floor's syntax level with

--- a/bun.lock
+++ b/bun.lock
@@ -5,15 +5,17 @@
     "": {
       "name": "screenly-weather-app",
       "dependencies": {
-        "@screenly-labs/signage-kit": "github:Screenly-Labs/signage-kit#2026.7.2",
+        "@screenly-labs/signage-kit": "github:Screenly-Labs/signage-kit#2026.7.3",
         "hono": "^4.12.27",
       },
       "devDependencies": {
         "@biomejs/biome": "^2.5.1",
         "@cloudflare/workers-types": "^4.20260623.1",
+        "@happy-dom/global-registrator": "^20.10.6",
         "browserslist": "^4.28.6",
         "esbuild": "^0.28.1",
         "lightningcss": "^1.32.0",
+        "qrcode": "^1.5.4",
         "wrangler": "^4.104.0",
       },
     },
@@ -121,6 +123,8 @@
 
     "@fontsource/space-mono": ["@fontsource/space-mono@5.2.9", "", {}, "sha512-b61faFOHEISQ/pD25G+cfGY9o/WW6lRv6hBQQfpWvEJ4y1V+S4gmth95EVyBE2VL3qDYHeVQ8nBzrplzdXTDDg=="],
 
+    "@happy-dom/global-registrator": ["@happy-dom/global-registrator@20.10.6", "", { "dependencies": { "@types/node": ">=20.0.0", "happy-dom": "^20.10.6" } }, "sha512-Nu/IjRkkNxmeG2ywWsyJSO4d1BrWTqVzxCPL+gXj0b97klhmjd6wLzt6Bx/laNpkZ3WLW7zNCqmtMIbIlahqug=="],
+
     "@img/colour": ["@img/colour@1.1.0", "", {}, "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ=="],
 
     "@img/sharp-darwin-arm64": ["@img/sharp-darwin-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-arm64": "1.2.4" }, "os": "darwin", "cpu": "arm64" }, "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w=="],
@@ -183,11 +187,21 @@
 
     "@poppinss/exception": ["@poppinss/exception@1.2.3", "", {}, "sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw=="],
 
-    "@screenly-labs/signage-kit": ["@screenly-labs/signage-kit@github:Screenly-Labs/signage-kit#b7f3d44", { "dependencies": { "@fontsource-variable/bricolage-grotesque": "^5.2.10", "@fontsource-variable/fraunces": "^5.2.9", "@fontsource-variable/hanken-grotesk": "^5.2.8", "@fontsource-variable/jetbrains-mono": "^5.2.8", "@fontsource-variable/newsreader": "^5.2.10", "@fontsource/space-mono": "^5.2.9" }, "peerDependencies": { "@csstools/postcss-cascade-layers": "^6", "browserslist": "^4", "esbuild": "^0.28", "lightningcss": "^1.32", "postcss": "^8" }, "optionalPeers": ["@csstools/postcss-cascade-layers", "postcss"] }, "Screenly-Labs-signage-kit-b7f3d44", "sha512-42YdnSCPpYpTyMucl1T+FGv3HQeyzz2UDEvYoLdP4EMVAD1m0U1G8WN2hgTE4vFVs3w8hGcqFisWBjkEc26rFA=="],
+    "@screenly-labs/signage-kit": ["@screenly-labs/signage-kit@github:Screenly-Labs/signage-kit#079188f", { "dependencies": { "@fontsource-variable/bricolage-grotesque": "^5.2.10", "@fontsource-variable/fraunces": "^5.2.9", "@fontsource-variable/hanken-grotesk": "^5.2.8", "@fontsource-variable/jetbrains-mono": "^5.2.8", "@fontsource-variable/newsreader": "^5.2.10", "@fontsource/space-mono": "^5.2.9" }, "peerDependencies": { "@csstools/postcss-cascade-layers": "^6", "browserslist": "^4", "esbuild": "^0.28", "lightningcss": "^1.32", "postcss": "^8" }, "optionalPeers": ["@csstools/postcss-cascade-layers", "postcss"] }, "Screenly-Labs-signage-kit-079188f", "sha512-vonA+XyyGs03eN9LVQdWB2gS5oBXUj08LdITRL1ocyp5iTuCzPC0+BUMnY6FitVyfU+nL+Ws7Uq6ZWkGHz3ZSQ=="],
 
     "@sindresorhus/is": ["@sindresorhus/is@7.2.0", "", {}, "sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw=="],
 
     "@speed-highlight/core": ["@speed-highlight/core@1.2.17", "", {}, "sha512-Z92FwKpCtfaW1V0jTU/fh3QzYEZN8wDwrzRIBoADCJfn4mJCNcJN/XegifX7BDrQ8/h9Xh/JnbyMchL0FqXrkg=="],
+
+    "@types/node": ["@types/node@26.1.1", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw=="],
+
+    "@types/whatwg-mimetype": ["@types/whatwg-mimetype@3.0.2", "", {}, "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA=="],
+
+    "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
+
+    "ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
     "baseline-browser-mapping": ["baseline-browser-mapping@2.10.43", "", { "bin": { "baseline-browser-mapping": "dist/cli.cjs" } }, "sha512-AjYpR78kDWAY3Efj+cDTFH9t9SCoL7OoTp1BOb0mQV7S+6CiLwnWM3FyxhJtdPufDFKzmCSFoUncKjWgJEZTCQ=="],
 
@@ -195,13 +209,31 @@
 
     "browserslist": ["browserslist@4.28.6", "", { "dependencies": { "baseline-browser-mapping": "^2.10.42", "caniuse-lite": "^1.0.30001803", "electron-to-chromium": "^1.5.389", "node-releases": "^2.0.51", "update-browserslist-db": "^1.2.3" }, "bin": { "browserslist": "cli.js" } }, "sha512-FQBYNK15VMslhLHpA7+n+n1GOlF1kId2xcCg7/j95f24AOF6VDYMNH4mFxF7KuaTdv627faazpOAjFzMrfJOUw=="],
 
+    "buffer-image-size": ["buffer-image-size@0.6.4", "", { "dependencies": { "@types/node": "*" } }, "sha512-nEh+kZOPY1w+gcCMobZ6ETUp9WfibndnosbpwB1iJk/8Gt5ZF2bhS6+B6bPYz424KtwsR6Rflc3tCz1/ghX2dQ=="],
+
+    "camelcase": ["camelcase@5.3.1", "", {}, "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="],
+
     "caniuse-lite": ["caniuse-lite@1.0.30001805", "", {}, "sha512-52noaS3DubycKSXaU30TwPGIp+POyQSUVa5jBEq3vkRkY0kjyb3LQgvhU6WGyCcyXqVLWO0Cw0Q6BSdD0kUfVA=="],
+
+    "cliui": ["cliui@6.0.0", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.0", "wrap-ansi": "^6.2.0" } }, "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ=="],
+
+    "color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
+
+    "color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
 
     "cookie": ["cookie@1.1.1", "", {}, "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="],
 
+    "decamelize": ["decamelize@1.2.0", "", {}, "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA=="],
+
     "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
 
+    "dijkstrajs": ["dijkstrajs@1.0.3", "", {}, "sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA=="],
+
     "electron-to-chromium": ["electron-to-chromium@1.5.389", "", {}, "sha512-cEto7aeOqBfU1D+c5py5pE+ooscKE75JifxLBdFUZsqAxRS6y7kebtxAZvICszSl05gPjYHDTjY+lXpyGvpJbg=="],
+
+    "emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+
+    "entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
 
     "error-stack-parser-es": ["error-stack-parser-es@1.0.5", "", {}, "sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA=="],
 
@@ -209,9 +241,17 @@
 
     "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
 
+    "find-up": ["find-up@4.1.0", "", { "dependencies": { "locate-path": "^5.0.0", "path-exists": "^4.0.0" } }, "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw=="],
+
     "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
+    "get-caller-file": ["get-caller-file@2.0.5", "", {}, "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="],
+
+    "happy-dom": ["happy-dom@20.10.6", "", { "dependencies": { "@types/node": ">=20.0.0", "@types/whatwg-mimetype": "^3.0.2", "@types/ws": "^8.18.1", "buffer-image-size": "^0.6.4", "entities": "^7.0.1", "whatwg-mimetype": "^3.0.0", "ws": "^8.21.0" } }, "sha512-6QD0ilzDDt93tX44y8tbmZdAcdTRYDhUP+Asgi6pC8Pp5IA3cvaZGyoVN/EGtlq9ziT65iPuBBn3ASLr6hCgVw=="],
+
     "hono": ["hono@4.12.27", "", {}, "sha512-1yrb/+w6HWQJrUCLkJ2IF5jNIPvvFkblV5RNOYl6bV+OA6p9GLcMpHFFGTosSvHvcAUibuUukRqhlYI4z32C7Q=="],
+
+    "is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
 
     "kleur": ["kleur@4.1.5", "", {}, "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ=="],
 
@@ -239,9 +279,19 @@
 
     "lightningcss-win32-x64-msvc": ["lightningcss-win32-x64-msvc@1.32.0", "", { "os": "win32", "cpu": "x64" }, "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q=="],
 
+    "locate-path": ["locate-path@5.0.0", "", { "dependencies": { "p-locate": "^4.1.0" } }, "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g=="],
+
     "miniflare": ["miniflare@4.20260623.0", "", { "dependencies": { "@cspotcode/source-map-support": "0.8.1", "sharp": "0.34.5", "undici": "7.28.0", "workerd": "1.20260623.1", "ws": "8.21.0", "youch": "4.1.0-beta.10" }, "bin": { "miniflare": "bootstrap.js" } }, "sha512-p2YTeH01jMiMOjO4v9hb/+GJndja5LCxecGOWCaT9F414PRXgdddLDsK6MnqhGBB5tlU/WoBYIG1XZte5pQzOQ=="],
 
     "node-releases": ["node-releases@2.0.51", "", {}, "sha512-wRNIrw4DmVLKQlbgOMdkMx27Wrpzes2hh5Jtbi2bjPd+4wJstWIqP5A+lscnqbm0xxmT5Bpg8Lec5ItEBwx6BQ=="],
+
+    "p-limit": ["p-limit@2.3.0", "", { "dependencies": { "p-try": "^2.0.0" } }, "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w=="],
+
+    "p-locate": ["p-locate@4.1.0", "", { "dependencies": { "p-limit": "^2.2.0" } }, "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A=="],
+
+    "p-try": ["p-try@2.2.0", "", {}, "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="],
+
+    "path-exists": ["path-exists@4.0.0", "", {}, "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="],
 
     "path-to-regexp": ["path-to-regexp@6.3.0", "", {}, "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ=="],
 
@@ -249,9 +299,23 @@
 
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
+    "pngjs": ["pngjs@5.0.0", "", {}, "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw=="],
+
+    "qrcode": ["qrcode@1.5.4", "", { "dependencies": { "dijkstrajs": "^1.0.1", "pngjs": "^5.0.0", "yargs": "^15.3.1" }, "bin": { "qrcode": "bin/qrcode" } }, "sha512-1ca71Zgiu6ORjHqFBDpnSMTR2ReToX4l1Au1VFLyVeBTFavzQnv5JxMFr3ukHVKpSrSA2MCk0lNJSykjUfz7Zg=="],
+
+    "require-directory": ["require-directory@2.1.1", "", {}, "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="],
+
+    "require-main-filename": ["require-main-filename@2.0.0", "", {}, "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg=="],
+
     "semver": ["semver@7.8.5", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA=="],
 
+    "set-blocking": ["set-blocking@2.0.0", "", {}, "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw=="],
+
     "sharp": ["sharp@0.34.5", "", { "dependencies": { "@img/colour": "^1.0.0", "detect-libc": "^2.1.2", "semver": "^7.7.3" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "0.34.5", "@img/sharp-darwin-x64": "0.34.5", "@img/sharp-libvips-darwin-arm64": "1.2.4", "@img/sharp-libvips-darwin-x64": "1.2.4", "@img/sharp-libvips-linux-arm": "1.2.4", "@img/sharp-libvips-linux-arm64": "1.2.4", "@img/sharp-libvips-linux-ppc64": "1.2.4", "@img/sharp-libvips-linux-riscv64": "1.2.4", "@img/sharp-libvips-linux-s390x": "1.2.4", "@img/sharp-libvips-linux-x64": "1.2.4", "@img/sharp-libvips-linuxmusl-arm64": "1.2.4", "@img/sharp-libvips-linuxmusl-x64": "1.2.4", "@img/sharp-linux-arm": "0.34.5", "@img/sharp-linux-arm64": "0.34.5", "@img/sharp-linux-ppc64": "0.34.5", "@img/sharp-linux-riscv64": "0.34.5", "@img/sharp-linux-s390x": "0.34.5", "@img/sharp-linux-x64": "0.34.5", "@img/sharp-linuxmusl-arm64": "0.34.5", "@img/sharp-linuxmusl-x64": "0.34.5", "@img/sharp-wasm32": "0.34.5", "@img/sharp-win32-arm64": "0.34.5", "@img/sharp-win32-ia32": "0.34.5", "@img/sharp-win32-x64": "0.34.5" } }, "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg=="],
+
+    "string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+
+    "strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
     "supports-color": ["supports-color@10.2.2", "", {}, "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g=="],
 
@@ -259,15 +323,29 @@
 
     "undici": ["undici@7.28.0", "", {}, "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA=="],
 
+    "undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
+
     "unenv": ["unenv@2.0.0-rc.24", "", { "dependencies": { "pathe": "^2.0.3" } }, "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw=="],
 
     "update-browserslist-db": ["update-browserslist-db@1.2.3", "", { "dependencies": { "escalade": "^3.2.0", "picocolors": "^1.1.1" }, "peerDependencies": { "browserslist": ">= 4.21.0" }, "bin": { "update-browserslist-db": "cli.js" } }, "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w=="],
+
+    "whatwg-mimetype": ["whatwg-mimetype@3.0.0", "", {}, "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q=="],
+
+    "which-module": ["which-module@2.0.1", "", {}, "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ=="],
 
     "workerd": ["workerd@1.20260623.1", "", { "optionalDependencies": { "@cloudflare/workerd-darwin-64": "1.20260623.1", "@cloudflare/workerd-darwin-arm64": "1.20260623.1", "@cloudflare/workerd-linux-64": "1.20260623.1", "@cloudflare/workerd-linux-arm64": "1.20260623.1", "@cloudflare/workerd-windows-64": "1.20260623.1" }, "bin": { "workerd": "bin/workerd" } }, "sha512-9SJsdTSsehhqc26TUJIzyi1XgyYeqFym4hinZnWoAP1BkhEoMQ5Ygz7Xw9T+2ecU+y409JBEScBgWTdZ06mBrg=="],
 
     "wrangler": ["wrangler@4.104.0", "", { "dependencies": { "@cloudflare/kv-asset-handler": "0.5.0", "@cloudflare/unenv-preset": "2.16.1", "blake3-wasm": "2.1.5", "esbuild": "0.28.1", "miniflare": "4.20260623.0", "path-to-regexp": "6.3.0", "unenv": "2.0.0-rc.24", "workerd": "1.20260623.1" }, "optionalDependencies": { "fsevents": "2.3.3" }, "peerDependencies": { "@cloudflare/workers-types": "^4.20260623.1" }, "optionalPeers": ["@cloudflare/workers-types"], "bin": { "cf-wrangler": "bin/cf-wrangler.js", "wrangler": "bin/wrangler.js", "wrangler2": "bin/wrangler.js" } }, "sha512-xCfbg2Oj93Bc7EMryFaSeRGDgV96dzrWoaK5q2q5XLEvumO4mysNP/1MDue0GUozEJAI6Z6vrGyYPLmfET/0sg=="],
 
+    "wrap-ansi": ["wrap-ansi@6.2.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA=="],
+
     "ws": ["ws@8.21.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g=="],
+
+    "y18n": ["y18n@4.0.3", "", {}, "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ=="],
+
+    "yargs": ["yargs@15.4.1", "", { "dependencies": { "cliui": "^6.0.0", "decamelize": "^1.2.0", "find-up": "^4.1.0", "get-caller-file": "^2.0.1", "require-directory": "^2.1.1", "require-main-filename": "^2.0.0", "set-blocking": "^2.0.0", "string-width": "^4.2.0", "which-module": "^2.0.0", "y18n": "^4.0.0", "yargs-parser": "^18.1.2" } }, "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A=="],
+
+    "yargs-parser": ["yargs-parser@18.1.3", "", { "dependencies": { "camelcase": "^5.0.0", "decamelize": "^1.2.0" } }, "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ=="],
 
     "youch": ["youch@4.1.0-beta.10", "", { "dependencies": { "@poppinss/colors": "^4.1.5", "@poppinss/dumper": "^0.6.4", "@speed-highlight/core": "^1.2.7", "cookie": "^1.0.2", "youch-core": "^0.3.3" } }, "sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ=="],
 

--- a/package.json
+++ b/package.json
@@ -16,15 +16,17 @@
   },
   "license": "AGPL-3.0-only",
   "dependencies": {
-    "@screenly-labs/signage-kit": "github:Screenly-Labs/signage-kit#2026.7.2",
+    "@screenly-labs/signage-kit": "github:Screenly-Labs/signage-kit#2026.7.3",
     "hono": "^4.12.27"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.5.1",
     "@cloudflare/workers-types": "^4.20260623.1",
+    "@happy-dom/global-registrator": "^20.10.6",
     "browserslist": "^4.28.6",
     "esbuild": "^0.28.1",
     "lightningcss": "^1.32.0",
+    "qrcode": "^1.5.4",
     "wrangler": "^4.104.0"
   }
 }

--- a/test/stale-player.test.js
+++ b/test/stale-player.test.js
@@ -1,0 +1,137 @@
+import { GlobalRegistrator } from '@happy-dom/global-registrator'
+import { describe, expect, it } from 'bun:test'
+
+// The notice builds real DOM, so this suite needs a document — Bun's runner has
+// no globals of its own. Registered before the module under test is imported.
+GlobalRegistrator.register()
+
+import { detectPlayer } from '@screenly-labs/signage-kit/profiler'
+import {
+  createStaleNotice,
+  isStalePlayer,
+  mountStaleNotice,
+  STALE_MESSAGE,
+  UPGRADE_URL
+} from '../assets/static/js/stale-player.js'
+
+// Real UA strings, kept identical to signage-kit's own profiler fixtures so this
+// suite fails loudly if the kit ever reclassifies one of them.
+const UA = {
+  // The target: QtWebEngine 5.15 / Chrome 83, carrying no vendor token at all.
+  oldAnthias:
+    'Mozilla/5.0 (X11; Linux aarch64) AppleWebKit/537.36 (KHTML, like Gecko) QtWebEngine/5.15.2 Chrome/83.0.4103.122 Safari/537.36',
+  // Current Anthias tags itself and is on Qt6 / Chrome 122.
+  currentAnthias:
+    'Mozilla/5.0 (X11; Linux aarch64) AppleWebKit/537.36 (KHTML, like Gecko) QtWebEngine/6.8.2 Chrome/122.0.6261.171 Safari/537.36 Anthias/2026.7.1',
+  // Same old engine, but identifies itself — must not be told to upgrade Anthias.
+  brightsign:
+    'BrightSign/UJE9C2001890/8.0.94 (XT1144)Mozilla/5.0 (X11; Linux aarch64) AppleWebKit/537.36 (KHTML, like Gecko) QtWebEngine/5.11.2 Chrome/65.0.3325.230 Safari/537.36',
+  screenly:
+    'Mozilla/5.0 (X11; Linux aarch64) AppleWebKit/537.36 (KHTML, like Gecko) QtWebEngine/5.15.2 Chrome/83.0.4103.122 Safari/537.36 screenly-viewer/2.0',
+  chrome:
+    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36'
+}
+
+const profile = (ua) => detectPlayer(ua, '')
+
+describe('isStalePlayer', () => {
+  it('flags an untagged QtWebEngine player as old Anthias', () => {
+    expect(isStalePlayer(profile(UA.oldAnthias))).toBe(true)
+    // The profiler will not name Anthias here — that is expected, and is the
+    // whole reason the predicate keys on the absence of a vendor instead.
+    expect(profile(UA.oldAnthias).vendor).toBeNull()
+  })
+
+  it('leaves current, self-tagged Anthias alone', () => {
+    // Guards the whole point of the feature: a player that is already up to date
+    // must never be told it is out of date.
+    expect(profile(UA.currentAnthias).vendor).toBe('anthias')
+    expect(isStalePlayer(profile(UA.currentAnthias))).toBe(false)
+  })
+
+  it('does not tell BrightSign to upgrade Anthias, despite the same old engine', () => {
+    const p = profile(UA.brightsign)
+    expect(p.engine.name).toBe('qtwebengine')
+    expect(isStalePlayer(p)).toBe(false)
+  })
+
+  it('flags an untagged player even on a current engine', () => {
+    // Sending the Anthias/ token is what marks a build as current, so reaching
+    // Qt6 without it still means out of date.
+    const p = profile(
+      'Mozilla/5.0 (X11; Linux aarch64) AppleWebKit/537.36 (KHTML, like Gecko) QtWebEngine/6.8.2 Chrome/122.0.6261.171 Safari/537.36'
+    )
+    expect(p.belowFloor).toBe(false)
+    expect(isStalePlayer(p)).toBe(true)
+  })
+
+  it('does not tell a Screenly player to upgrade Anthias', () => {
+    expect(isStalePlayer(profile(UA.screenly))).toBe(false)
+  })
+
+  it('leaves an ordinary desktop browser alone', () => {
+    expect(isStalePlayer(profile(UA.chrome))).toBe(false)
+  })
+
+  it('stays quiet on a non-QtWebEngine player with no vendor', () => {
+    // The notice is an accusation; an unrecognised engine gets the benefit of
+    // the doubt rather than a guess.
+    const p = { vendor: null, engine: { name: null, version: null }, belowFloor: null }
+    expect(isStalePlayer(p)).toBe(false)
+  })
+})
+
+describe('createStaleNotice', () => {
+  it('encodes the upgrade URL in the alt text so it is reachable without a camera', () => {
+    const el = createStaleNotice(document, 'abc123')
+    expect(el.querySelector('.stale-notice-qr').alt).toContain(UPGRADE_URL)
+  })
+
+  it('carries the UTM campaign on the URL the QR encodes', () => {
+    const url = new URL(UPGRADE_URL)
+    // utm_source is what splits this app's share out of a campaign the clock app
+    // also runs; the campaign name is shared between them on purpose.
+    expect(url.searchParams.get('utm_source')).toBe('weather-app')
+    expect(url.searchParams.get('utm_medium')).toBe('qr')
+    expect(url.searchParams.get('utm_campaign')).toBe('anthias-stale-player')
+  })
+
+  it('versions the QR src so it gets the immutable asset cache', () => {
+    expect(createStaleNotice(document, 'abc123').querySelector('.stale-notice-qr').src).toContain(
+      '?v=abc123'
+    )
+  })
+
+  it('omits the version query when no asset version is available', () => {
+    const src = createStaleNotice(document, '').querySelector('.stale-notice-qr').src
+    expect(src).toContain('/static/images/anthias-upgrade-qr.svg')
+    expect(src).not.toContain('?v=')
+  })
+
+  it('speaks in the player’s own voice', () => {
+    expect(createStaleNotice(document, 'v').querySelector('.stale-notice-text').textContent).toBe(
+      STALE_MESSAGE
+    )
+  })
+})
+
+describe('mountStaleNotice', () => {
+  it('mounts once for a stale player', () => {
+    document.body.innerHTML = ''
+    expect(mountStaleNotice(profile(UA.oldAnthias), document, 'v')).toBe(true)
+    expect(document.querySelectorAll('.stale-notice').length).toBe(1)
+  })
+
+  it('does not mount twice if called again', () => {
+    document.body.innerHTML = ''
+    mountStaleNotice(profile(UA.oldAnthias), document, 'v')
+    expect(mountStaleNotice(profile(UA.oldAnthias), document, 'v')).toBe(false)
+    expect(document.querySelectorAll('.stale-notice').length).toBe(1)
+  })
+
+  it('mounts nothing for a healthy player', () => {
+    document.body.innerHTML = ''
+    expect(mountStaleNotice(profile(UA.currentAnthias), document, 'v')).toBe(false)
+    expect(document.querySelector('.stale-notice')).toBeNull()
+  })
+})

--- a/test/stale-player.test.js
+++ b/test/stale-player.test.js
@@ -2,7 +2,11 @@ import { GlobalRegistrator } from '@happy-dom/global-registrator'
 import { describe, expect, it } from 'bun:test'
 
 // The notice builds real DOM, so this suite needs a document — Bun's runner has
-// no globals of its own. Registered before the module under test is imported.
+// no globals of its own. This runs after the static imports below are evaluated
+// (ESM hoists them), not before; what it has to beat is the first *test*, which
+// it does. That ordering is only safe because stale-player.js touches no DOM at
+// import time — it just defines functions and takes `doc` as an argument. Keep
+// it that way, or this needs a dynamic import instead.
 GlobalRegistrator.register()
 
 import { detectPlayer } from '@screenly-labs/signage-kit/profiler'
@@ -106,6 +110,15 @@ describe('createStaleNotice', () => {
     const src = createStaleNotice(document, '').querySelector('.stale-notice-qr').src
     expect(src).toContain('/static/images/anthias-upgrade-qr.svg')
     expect(src).not.toContain('?v=')
+  })
+
+  it('is not a live region — there is nothing to announce', () => {
+    // `status` would be an implicit aria-live="polite", which would interrupt to
+    // read out copy that has been on the page since first paint. Guards against
+    // that creeping back in.
+    const el = createStaleNotice(document, 'v')
+    expect(el.getAttribute('role')).toBe('note')
+    expect(el.hasAttribute('aria-live')).toBe(false)
   })
 
   it('speaks in the player’s own voice', () => {


### PR DESCRIPTION
Ports the clock app's stale-player notice ([clock-app#30](https://github.com/Screenly-Labs/clock-app/pull/30)) to the weather app.

## What ships

Old Anthias players (bare `QtWebEngine`, no product token) get a service-tag notice pointing at the free upgrade via QR. Every player that identifies itself — current Anthias, Screenly, BrightSign — and every ordinary browser sees nothing.

The check runs client-side on purpose: the SSR page cache is keyed on `?lat=&lng=` + `ASSET_VERSION` and carries **no user-agent component**, so a server-rendered notice would be cached once and then served to every player regardless of what it is running.

Also picks up signage-kit `2026.7.2` → `2026.7.3`. This one is **required, not cosmetic**: `2026.7.2` declares a `./profiler` export whose file it does not ship. The bump also fixes a pre-existing bug unrelated to this feature — the old `includes('screenly-viewer')` check returned `false` for `ScreenlyWebview` devices, so those Screenly players were being shown the promotional badge. The new `SCREENLY_UA` regex catches them.

## Deliberate divergences from the clock app

Both forced by this app's layout, not preference:

- **The tag sits on the right edge, vertically centred**, not bottom-left. Bottom-left is the full-width forecast rail here, and `.brand` holds the bottom right. The midrow's right half is the one region empty in both orientations.
- **`z-index: 4`, not 3** — to clear this app's `mix-blend-mode: soft-light` grain overlay (`.content::after`, z-index 3), which the clock does not have. At 3 the film would render over the tag.

The QR is **gitignored rather than committed**, matching how this repo already treats the built `main.js`. Deploy runs `bun run build`, so it is produced on the way out. It is encoded from `UPGRADE_URL` in `stale-player.js` — the same module the alt text reads — so the image and the link can never drift apart.

## Verified against the live site

Driven against production (`weather.srly.io`, real data + real webfonts), because [CLAUDE.md](../blob/master/CLAUDE.md) is explicit that `bun run dev` does not render like production:

| check | 1080p | 720p | portrait |
|---|---|---|---|
| collisions with hero / rail / badge / masthead | none | none | none |
| QR decoded via `zbarimg` from rendered pixels | exact UTM URL | exact UTM URL | exact UTM URL |
| copy line breaks | 3, no orphan | 3, no orphan | 3, no orphan |

Fonts asserted loaded (`document.fonts.check`) before measuring, and `.content` checked for clipping — both per the CLAUDE.md warnings.

Separately, the six-UA matrix was driven through the **real built bundle** (not a stub) with a stubbed `/api/weather`:

| UA | notice | badge |
|---|---|---|
| old Anthias (untagged Qt5) | shown | kept |
| current Anthias (`Anthias/`) | absent | kept |
| Screenly (`screenly-viewer/2.0`) | absent | removed |
| Screenly (`ScreenlyWebview`) | absent | removed |
| BrightSign (same old engine) | absent | kept |
| desktop Chrome | absent | kept |

No page errors in any case. Plus 15 new unit tests (75 pass total), lint clean.

## Not verified

A physical phone scanning a physical sign at distance/angle. The QR is proven to decode from rendered pixels at every resolution, but that is synthetic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)