### PR TITLE
Record why platform cannot narrow the stale-player test

### DIFF
--- a/assets/static/js/stale-player.js
+++ b/assets/static/js/stale-player.js
@@ -23,23 +23,27 @@
 // whichever Chromium it carries — gating on belowFloor as well would miss a
 // build new enough to have reached Qt6 but still too old to identify itself.
 //
-// And don't reach for `profile.platform` to narrow the bucket. It looks like the
-// obvious way to say "Anthias is Raspberry Pi first", but it is measured, not
-// guessed, and the measurement says no:
+// And don't reach for `profile.platform` to narrow the bucket. "Anthias is
+// Raspberry Pi first, so require platform 'raspberry-pi'" is the obvious
+// tightening, and it fails silently: the profiler sets that platform only from a
+// literal `Raspbian` token, which the old Anthias UA does not carry, so the
+// narrowed predicate would match no player at all. Not a tighter notice, a
+// notice that never fires. Same shape of mistake as the `vendor === 'anthias'`
+// trap above.
 //
-//   * Every QtWebEngine player resolves to platform 'linux', old Anthias and
-//     BrightSign alike, so the field has no separating power here at all.
-//   * 'raspberry-pi' comes only from a literal `Raspbian` token, which the old
-//     Anthias UA does not carry. Requiring it matches NO player, so it would not
-//     tighten the notice, it would silently switch it off. Same shape of mistake
-//     as the `vendor === 'anthias'` trap above.
+// Platform gives nothing to discriminate on here either. The UAs on both sides
+// of this test are X11/Linux, so the ones the suite pins (old Anthias and
+// BrightSign) both report 'linux' and the field cannot separate them. That is a
+// statement about these players, not about QtWebEngine in general.
 //
-// The BrightSign exclusion is also sturdier than it looks. Its roHtmlWidget lets
-// an integrator replace the UA outright, which would drop the `BrightSign/`
-// token this relies on. But a hand-written replacement does not carry a
-// `QtWebEngine` token either, so such a player fails this test on the engine
-// instead of the vendor and still sees nothing. Only a verbatim copy of the
-// stock UA with the product token surgically removed would misfire.
+// The BrightSign exclusion is sturdier than it looks, which is worth knowing
+// because it leans on a product token: roHtmlWidget lets an integrator replace
+// the UA outright and drop `BrightSign/`. A replacement written by hand is
+// unlikely to name `QtWebEngine`, and one that does not fails this test on the
+// engine rather than the vendor, so it still sees nothing. The gap is a UA that
+// keeps the engine token but loses the product token, i.e. the stock string with
+// only `BrightSign/` cut out. Left unguarded on purpose: nothing in the UA
+// separates that from the players this notice is for.
 export const isStalePlayer = (profile) =>
   profile.vendor === null && profile.engine.name === 'qtwebengine'
 

--- a/assets/static/js/stale-player.js
+++ b/assets/static/js/stale-player.js
@@ -22,6 +22,24 @@
 // itself the mark of a current build, so an untagged player is out of date
 // whichever Chromium it carries — gating on belowFloor as well would miss a
 // build new enough to have reached Qt6 but still too old to identify itself.
+//
+// And don't reach for `profile.platform` to narrow the bucket. It looks like the
+// obvious way to say "Anthias is Raspberry Pi first", but it is measured, not
+// guessed, and the measurement says no:
+//
+//   * Every QtWebEngine player resolves to platform 'linux', old Anthias and
+//     BrightSign alike, so the field has no separating power here at all.
+//   * 'raspberry-pi' comes only from a literal `Raspbian` token, which the old
+//     Anthias UA does not carry. Requiring it matches NO player, so it would not
+//     tighten the notice, it would silently switch it off. Same shape of mistake
+//     as the `vendor === 'anthias'` trap above.
+//
+// The BrightSign exclusion is also sturdier than it looks. Its roHtmlWidget lets
+// an integrator replace the UA outright, which would drop the `BrightSign/`
+// token this relies on. But a hand-written replacement does not carry a
+// `QtWebEngine` token either, so such a player fails this test on the engine
+// instead of the vendor and still sees nothing. Only a verbatim copy of the
+// stock UA with the product token surgically removed would misfire.
 export const isStalePlayer = (profile) =>
   profile.vendor === null && profile.engine.name === 'qtwebengine'
 

--- a/test/stale-player.test.js
+++ b/test/stale-player.test.js
@@ -89,10 +89,13 @@ describe('isStalePlayer', () => {
     expect(profile(UA.brightsign).platform).toBe('linux')
   })
 
-  it('stays quiet on a BrightSign that replaced its UA with a custom string', () => {
-    // roHtmlWidget lets an integrator replace the UA, dropping the BrightSign/
-    // token the exclusion leans on. Safe regardless: a hand-written UA carries no
-    // QtWebEngine token either, so it fails on the engine instead of the vendor.
+  it('stays quiet on a custom UA that names no engine', () => {
+    // Why this case is here: roHtmlWidget lets a BrightSign integrator replace
+    // the UA and drop the `BrightSign/` token the exclusion leans on. Nothing
+    // then identifies the device as BrightSign, which is exactly the point of
+    // the fixture below being an arbitrary custom string rather than anything
+    // BrightSign-shaped: it is what such a player looks like from here. It fails
+    // this test on the engine instead of the vendor, so it still sees nothing.
     const p = profile('AcmeKiosk/1.0')
     expect(p.vendor).toBeNull()
     expect(p.engine.name).toBeNull()

--- a/test/stale-player.test.js
+++ b/test/stale-player.test.js
@@ -77,6 +77,28 @@ describe('isStalePlayer', () => {
     expect(isStalePlayer(profile(UA.chrome))).toBe(false)
   })
 
+  it('does not resolve old Anthias to raspberry-pi, so platform cannot gate this', () => {
+    // Pins the reason isStalePlayer ignores profile.platform. "Anthias is Pi
+    // first, so require platform raspberry-pi" is the tempting narrowing, and it
+    // would match nothing: the platform only comes from a literal Raspbian token
+    // that the target UA does not send. If this ever starts reporting
+    // 'raspberry-pi', the comment on isStalePlayer needs revisiting.
+    expect(profile(UA.oldAnthias).platform).toBe('linux')
+    // And platform is not a discriminator anyway: the player we exclude reports
+    // exactly the same one.
+    expect(profile(UA.brightsign).platform).toBe('linux')
+  })
+
+  it('stays quiet on a BrightSign that replaced its UA with a custom string', () => {
+    // roHtmlWidget lets an integrator replace the UA, dropping the BrightSign/
+    // token the exclusion leans on. Safe regardless: a hand-written UA carries no
+    // QtWebEngine token either, so it fails on the engine instead of the vendor.
+    const p = profile('AcmeKiosk/1.0')
+    expect(p.vendor).toBeNull()
+    expect(p.engine.name).toBeNull()
+    expect(isStalePlayer(p)).toBe(false)
+  })
+
   it('stays quiet on a non-QtWebEngine player with no vendor', () => {
     // The notice is an accusation; an unrecognised engine gets the benefit of
     // the doubt rather than a guess.


### PR DESCRIPTION
Follow-up to #78. **Comments and tests only** — `isStalePlayer` is unchanged, and no player sees anything different.

## Why

Reviewing #78, the question came up: BrightSign is plausibly the largest QtWebEngine population out there, so how safe is "untagged QtWebEngine ⇒ old Anthias" really? Two things fell out of digging into it, and both are worth pinning down so the next person doesn't have to re-derive them.

### 1. `platform` cannot narrow this test (the actionable one)

"Anthias is Raspberry Pi first, so require `platform === 'raspberry-pi'`" is the obvious tightening. It is wrong, and it **fails silently**:

| UA | vendor | platform | stale? |
|---|---|---|---|
| old Anthias (untagged Qt5) | `null` | **`linux`** | true |
| BrightSign XT1144 (tagged) | `brightsign` | **`linux`** | false |
| hypothetical `Raspbian` UA | `null` | `raspberry-pi` | true |

The profiler sets `raspberry-pi` only from a literal `Raspbian` token, which the old Anthias UA **does not carry**. So the narrowed predicate matches *no player at all* — not a tighter notice, a notice that never fires. It is the same shape of mistake as the `vendor === 'anthias'` trap already documented directly above it.

And `platform` carries no signal here regardless: every QtWebEngine player resolves to `linux`, the excluded BrightSign included.

### 2. The BrightSign exclusion is sturdier than it looks (the reassuring one)

"What if BrightSign overrides its UA?" is a fair question of a check that leans on a product token. [`roHtmlWidget`](https://docs.brightsign.biz/developers/rohtmlwidget) does let an integrator replace the UA outright, which would drop the `BrightSign/` token. Safe anyway — a hand-written replacement carries no `QtWebEngine` token either, so it fails on the *engine* instead of the *vendor*:

| custom UA | engine | vendor | result |
|---|---|---|---|
| `AcmeKiosk/1.0` | `null` | `null` | safe |
| mimic desktop Chrome (common CMS workaround) | `chromium` | `null` | safe |
| mimic iPad | `webkit` | `null` | safe |
| default + appended suffix | `qtwebengine` | `brightsign` | safe |
| *contrived: stock UA, product token surgically excised* | `qtwebengine` | `null` | misfire |

Only the contrived last row misfires, and nobody hand-writes a UA that says `QtWebEngine`.

## Verification

Both facts are pinned by tests rather than left as prose, so they fail loudly if signage-kit ever reclassifies these UAs. 18 tests pass in the suite, lint clean. No runtime surface changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)